### PR TITLE
Add tool name prefixing option for MCP servers

### DIFF
--- a/apps/docs/concepts/configuration.mdx
+++ b/apps/docs/concepts/configuration.mdx
@@ -35,7 +35,9 @@ Your configuration file is a JSON file that defines proxy connections (it’s lo
             "env": {
               "API_KEY": "your-key-here"
             }
-          }
+          },
+          // Optional: prefix all tool names from this server
+          "add_prefix": false
         },
         {
           "name": "streamable-or-sse-server",
@@ -43,13 +45,55 @@ Your configuration file is a JSON file that defines proxy connections (it’s lo
             "type": "http",
             // The url of the server, this can be either Streamable or SSE transports
             "url": "https://api.example.com/mcp"
-          }
+          },
+          // When true, all tools will be prefixed with "streamable-or-sse-server__"
+          "add_prefix": true
         }
       ]
     }
   ]
 }
 ```
+
+### Server Configuration Options
+
+Each server in the `servers` array supports the following fields:
+
+- **name** (required): A unique identifier for the server within this proxy
+- **transport** (required): The transport configuration (either `stdio` or `http`)
+- **add_prefix** (optional, default: `false`): When enabled, all tool names from this server will be prefixed with the server name followed by double underscores (`__`)
+
+#### Tool Name Prefixing
+
+The `add_prefix` option helps prevent naming conflicts when multiple MCP servers expose tools with the same name. When `add_prefix: true`:
+
+- A tool named `search` from a server named `github` becomes `github__search`
+- A tool named `execute` from a server named `code-runner` becomes `code-runner__execute`
+
+This is particularly useful when:
+- You're aggregating multiple MCP servers that might have overlapping tool names
+- You want to clearly identify which server provides which tool
+- You need to maintain compatibility with clients that expect specific tool naming patterns
+
+Example scenario:
+```json
+{
+  "servers": [
+    {
+      "name": "github",
+      "transport": { "type": "http", "url": "https://api.github.com/mcp" },
+      "add_prefix": true  // Tools: github__search, github__create_issue, etc.
+    },
+    {
+      "name": "gitlab", 
+      "transport": { "type": "http", "url": "https://api.gitlab.com/mcp" },
+      "add_prefix": true  // Tools: gitlab__search, gitlab__create_issue, etc.
+    }
+  ]
+}
+```
+
+Without prefixing, only one server's `search` tool would be accessible. With prefixing, both are available as distinct tools.
 
 ## config.env
 

--- a/apps/docs/sdk/gateway.mdx
+++ b/apps/docs/sdk/gateway.mdx
@@ -42,6 +42,8 @@ await gatewayClient.proxy.addServer.mutate({
       command: "npx",
       args: ["-y", "@director.run/cli", "http2stdio", "http://localhost:3673/my-server/sse"],
     },
+    // Optional: prefix all tool names with "my-server__"
+    add_prefix: false,
   },
 });
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -12,12 +12,9 @@
     },
     "apps/cli": {
       "name": "@director.run/cli",
-      "version": "0.0.40",
+      "version": "0.0.42",
       "bin": {
         "director": "./dist/cli.js",
-      },
-      "dependencies": {
-        "node-machine-id": "^1.1.12",
       },
       "devDependencies": {
         "@director.run/gateway": "workspace:*",
@@ -30,6 +27,7 @@
         "chalk": "^5.4.1",
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",
+        "node-machine-id": "^1.1.12",
         "semver": "^7.7.2",
         "superjson": "^2.2.2",
         "type-fest": "^4.40.0",
@@ -108,6 +106,7 @@
         "@trpc/next": "^11.1.3",
         "@trpc/react-query": "^11.1.3",
         "@trpc/tanstack-react-query": "^11.1.3",
+        "@vercel/analytics": "^1.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -888,6 +887,8 @@
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@vercel/analytics": ["@vercel/analytics@1.5.0", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 

--- a/packages/mcp/src/proxy-server.test.ts
+++ b/packages/mcp/src/proxy-server.test.ts
@@ -1,3 +1,4 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, test } from "vitest";
 import { ProxyServer } from "./proxy-server";
 import { SimpleClient } from "./simple-client";
@@ -57,5 +58,198 @@ describe("ProxyServer", () => {
 
     await streamableServerInstance.close();
     await sseServerInstance.close();
+  });
+
+  describe("add_prefix feature", () => {
+    test("should prefix tool names when add_prefix is true", async () => {
+      const streamableServer = await serveOverStreamable(
+        makeEchoServer(),
+        4524,
+      );
+      const sseServer = await serveOverSSE(makeFooBarServer(), 4525);
+
+      const proxy = new ProxyServer({
+        id: "test-proxy",
+        name: "test-proxy",
+        servers: [
+          {
+            ...makeHTTPTargetConfig({
+              name: "echo-service",
+              url: `http://localhost:4524/mcp`,
+            }),
+            add_prefix: true,
+          },
+          {
+            ...makeHTTPTargetConfig({
+              name: "foobar-service",
+              url: `http://localhost:4525/sse`,
+            }),
+            add_prefix: false,
+          },
+        ],
+      });
+
+      await proxy.connectTargets();
+
+      const client = await SimpleClient.createAndConnectToServer(proxy);
+      const tools = await client.listTools();
+
+      expect(tools.tools).toHaveLength(2);
+
+      // Check prefixed tool
+      const echoTool = tools.tools.find((t) => t.name === "echo-service__echo");
+      expect(echoTool).toBeDefined();
+      expect(echoTool?.description).toContain("[echo-service]");
+
+      // Check non-prefixed tool
+      const fooTool = tools.tools.find((t) => t.name === "foo");
+      expect(fooTool).toBeDefined();
+      expect(fooTool?.description).toContain("[foobar-service]");
+
+      // Verify prefixed tool is not accessible by original name
+      expect(tools.tools.find((t) => t.name === "echo")).toBeUndefined();
+
+      await streamableServer.close();
+      await sseServer.close();
+    });
+
+    test("should call prefixed tools with original names", async () => {
+      const streamableServer = await serveOverStreamable(
+        makeEchoServer(),
+        4526,
+      );
+
+      const proxy = new ProxyServer({
+        id: "test-proxy",
+        name: "test-proxy",
+        servers: [
+          {
+            ...makeHTTPTargetConfig({
+              name: "echo-service",
+              url: `http://localhost:4526/mcp`,
+            }),
+            add_prefix: true,
+          },
+        ],
+      });
+
+      await proxy.connectTargets();
+
+      const client = await SimpleClient.createAndConnectToServer(proxy);
+
+      // List tools first to populate the mapping
+      await client.listTools();
+
+      // Call the prefixed tool
+      const result = (await client.callTool({
+        name: "echo-service__echo",
+        arguments: {
+          message: "Hello, world!",
+        },
+      })) as CallToolResult;
+
+      expect(result.content[0].text).toContain("Hello, world!");
+
+      await streamableServer.close();
+    });
+
+    test("should handle multiple servers with add_prefix enabled", async () => {
+      const server1 = await serveOverStreamable(makeEchoServer(), 4527);
+      const server2 = await serveOverStreamable(makeFooBarServer(), 4528);
+
+      const proxy = new ProxyServer({
+        id: "test-proxy",
+        name: "test-proxy",
+        servers: [
+          {
+            ...makeHTTPTargetConfig({
+              name: "service-a",
+              url: `http://localhost:4527/mcp`,
+            }),
+            add_prefix: true,
+          },
+          {
+            ...makeHTTPTargetConfig({
+              name: "service-b",
+              url: `http://localhost:4528/mcp`,
+            }),
+            add_prefix: true,
+          },
+        ],
+      });
+
+      await proxy.connectTargets();
+
+      const client = await SimpleClient.createAndConnectToServer(proxy);
+      const tools = await client.listTools();
+
+      expect(tools.tools).toHaveLength(2);
+      expect(tools.tools.map((t) => t.name).sort()).toEqual([
+        "service-a__echo",
+        "service-b__foo",
+      ]);
+
+      await server1.close();
+      await server2.close();
+    });
+
+    test("should handle mixed prefixed and non-prefixed servers", async () => {
+      const echoServer1 = await serveOverStreamable(makeEchoServer(), 4529);
+      const echoServer2 = await serveOverStreamable(makeEchoServer(), 4530);
+
+      const proxy = new ProxyServer({
+        id: "test-proxy",
+        name: "test-proxy",
+        servers: [
+          {
+            ...makeHTTPTargetConfig({
+              name: "prefixed-echo",
+              url: `http://localhost:4529/mcp`,
+            }),
+            add_prefix: true,
+          },
+          {
+            ...makeHTTPTargetConfig({
+              name: "normal-echo",
+              url: `http://localhost:4530/mcp`,
+            }),
+            add_prefix: false,
+          },
+        ],
+      });
+
+      await proxy.connectTargets();
+
+      const client = await SimpleClient.createAndConnectToServer(proxy);
+      const tools = await client.listTools();
+
+      expect(tools.tools).toHaveLength(2);
+
+      // Both tools should exist with different names
+      expect(
+        tools.tools.find((t) => t.name === "prefixed-echo__echo"),
+      ).toBeDefined();
+      expect(tools.tools.find((t) => t.name === "echo")).toBeDefined();
+
+      // Both should be callable
+      const result1 = (await client.callTool({
+        name: "prefixed-echo__echo",
+        arguments: {
+          message: "Test 1",
+        },
+      })) as CallToolResult;
+      const result2 = (await client.callTool({
+        name: "echo",
+        arguments: {
+          message: "Test 2",
+        },
+      })) as CallToolResult;
+
+      expect(result1.content[0].text).toContain("Test 1");
+      expect(result2.content[0].text).toContain("Test 2");
+
+      await echoServer1.close();
+      await echoServer2.close();
+    });
   });
 });

--- a/packages/mcp/src/proxy-server.test.ts
+++ b/packages/mcp/src/proxy-server.test.ts
@@ -148,7 +148,7 @@ describe("ProxyServer", () => {
         },
       })) as CallToolResult;
 
-      expect(result.content[0].text).toContain("Hello, world!");
+      expect(result.content?.[0].text).toContain("Hello, world!");
 
       await streamableServer.close();
     });
@@ -245,8 +245,8 @@ describe("ProxyServer", () => {
         },
       })) as CallToolResult;
 
-      expect(result1.content[0].text).toContain("Test 1");
-      expect(result2.content[0].text).toContain("Test 2");
+      expect(result1.content?.[0].text).toContain("Test 1");
+      expect(result2.content?.[0].text).toContain("Test 2");
 
       await echoServer1.close();
       await echoServer2.close();

--- a/packages/mcp/src/proxy-target.ts
+++ b/packages/mcp/src/proxy-target.ts
@@ -12,7 +12,7 @@ const logger = getLogger(`mcp/proxy-target`);
 export type ProxyTargetTransport = ProxyTransport;
 
 export class ProxyTarget extends SimpleClient {
-  private attributes: ProxyTargetAttributes;
+  public readonly attributes: ProxyTargetAttributes;
   // TODO: this should be a computed property
   public readonly status: ProxyTargetStatus = "disconnected";
 

--- a/packages/utilities/src/schema.ts
+++ b/packages/utilities/src/schema.ts
@@ -104,6 +104,7 @@ export const proxyTargetAttributesSchema = z.object({
   name: slugStringSchema,
   transport: proxyTransport,
   source: ProxyTargetSourceSchema.optional(),
+  add_prefix: z.boolean().default(false).optional(),
 });
 
 export type ProxyTargetAttributes = z.infer<typeof proxyTargetAttributesSchema>;


### PR DESCRIPTION
## Summary

This PR adds an optional `add_prefix` configuration field to MCP server configurations. When enabled, all tool names from that server are prefixed with `{server_name}__`, preventing naming conflicts when multiple servers expose tools with the same name.

## Motivation

When working with AI agents and multiple MCP servers, it's often necessary to explicitly specify which server's tool the agent should use. Without prefixing, agents can't easily distinguish between tools with the same name from different servers. This change enables clearer communication with agents by allowing instructions like "use the github__search tool" vs "use the gitlab__search tool", making it unambiguous which server's functionality should be invoked. 

 ## Example

  ```json
  {
    "servers": [
      {
        "name": "github",
        "transport": { "type": "http", "url": "..." },
        "add_prefix": true  // Tools become: github__search, github__create_issue
      },
      {
        "name": "gitlab",
        "transport": { "type": "http", "url": "..." },
        "add_prefix": true  // Tools become: gitlab__search, gitlab__create_issue
      },
      {
        "name": "gitcat",
        "transport": { "type": "http", "url": "..." },
        // `add_prefix` is `false` by default, so tools from gitcat are: search, create_issue
      }
    ]
  }
```