### PR TITLE
Export registry router inputs and outputs

### DIFF
--- a/apps/registry/src/client.ts
+++ b/apps/registry/src/client.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@director.run/utilities/trpc";
 import { joinURL } from "@director.run/utilities/url";
+import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
 import type { AppRouter } from "./routers/trpc";
 
 export function createRegistryClient(
@@ -20,3 +21,7 @@ export function createRegistryClient(
 }
 
 export type RegistryClient = ReturnType<typeof createRegistryClient>;
+
+export type RegistryRouterInputs = inferRouterInputs<AppRouter>;
+
+export type RegistryRouterOutputs = inferRouterOutputs<AppRouter>;

--- a/apps/registry/src/routers/trpc/index.ts
+++ b/apps/registry/src/routers/trpc/index.ts
@@ -1,5 +1,6 @@
 import { AppError, ErrorCode } from "@director.run/utilities/error";
 import { t } from "@director.run/utilities/trpc";
+
 import * as trpcExpress from "@trpc/server/adapters/express";
 import { env } from "../../config";
 import type { Store } from "../../db/store";

--- a/apps/sdk/src/index.ts
+++ b/apps/sdk/src/index.ts
@@ -6,6 +6,8 @@ export {
 export {
   createRegistryClient,
   type RegistryClient,
+  type RegistryRouterInputs,
+  type RegistryRouterOutputs,
 } from "@director.run/registry/client";
 
 export function sayHello() {


### PR DESCRIPTION
Adds exports to the registry and sdk for the router outputs and inputs making it easier to work with the types outside of the project