### PR TITLE
Add `X-Cli-Version` header to the gateway

### DIFF
--- a/apps/cli/src/commands/core/serve.ts
+++ b/apps/cli/src/commands/core/serve.ts
@@ -41,6 +41,9 @@ export async function startGateway(successCallback?: () => void) {
           cliVersion: packageJson.version,
         },
       }),
+      headers: {
+        "X-Cli-Version": packageJson.version,
+      },
       oauth: {
         enabled: true,
         storage: "disk",

--- a/packages/gateway/src/gateway.test.ts
+++ b/packages/gateway/src/gateway.test.ts
@@ -1,0 +1,34 @@
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Gateway } from "./gateway";
+import {} from "./test/fixtures";
+
+const TEST_PORT = 4673;
+
+describe("Gateway", () => {
+  let gateway: Gateway;
+  beforeAll(async () => {
+    gateway = await Gateway.start({
+      port: TEST_PORT,
+      databaseFilePath: path.join(__dirname, "config.test.json"),
+      registryURL: "http://localhost:3000",
+      headers: {
+        "x-cli-version": "1.2.3",
+      },
+      oauth: {
+        enabled: true,
+        storage: "memory",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await gateway.proxyStore.purge();
+    await gateway.stop();
+  });
+
+  it("should include the custom header in the response", async () => {
+    const response = await fetch(`http://localhost:${TEST_PORT}`);
+    expect(response.headers.get("x-cli-version")).toBe("1.2.3");
+  });
+});

--- a/packages/gateway/src/gateway.ts
+++ b/packages/gateway/src/gateway.ts
@@ -41,6 +41,7 @@ export class Gateway {
       registryURL: string;
       allowedOrigins?: string[];
       telemetry?: Telemetry;
+      headers?: Record<string, string>;
       oauth?:
         | {
             enabled: boolean;
@@ -81,6 +82,15 @@ export class Gateway {
     });
     const app = express();
     const registryURL = attribs.registryURL;
+
+    if (attribs.headers) {
+      app.use((req, res, next) => {
+        Object.entries(attribs.headers || {}).forEach(([key, value]) => {
+          res.setHeader(key, value);
+        });
+        next();
+      });
+    }
 
     app.use(
       cors({


### PR DESCRIPTION
- This adds a `X-Cli-Version` header to all gateway http responses. 
- This should be used by the studio to check whether the cli is out of date and need to be updated (by comparing to latest NPM version).
- If it is out of date, it should block the UI and give clear update instructions
- This makes it easier to manage releases going forward 
- *Once* the next version of the cli is released, we should consider the absence of this header to mean that the cli is out of date and needs to be updated

Example:
```
(base) ➜  cli git:(main) ✗ curl -I localhost:3673
HTTP/1.1 404 Not Found
Vary: Origin
Content-Type: application/json; charset=utf-8
Date: Sun, 27 Jul 2025 10:53:37 GMT
Content-Length: 53
ETag: W/"35-s1LRlopzO3hUTS2/YvasCvvG8C0"
X-Powered-By: Express
X-Cli-Version: 0.0.51
```