### PR TITLE
If cli doesn't have version in health ignore block

### DIFF
--- a/apps/studio/src/components/connect/connection-status-provider.tsx
+++ b/apps/studio/src/components/connect/connection-status-provider.tsx
@@ -52,7 +52,7 @@ export function ConnectionStatusProvider({
   useEffect(() => {
     if (data) {
       setConnected(true);
-      if (data?.cliVersion !== cliPackage.version) {
+      if (data?.cliVersion && data.cliVersion !== cliPackage.version) {
         setNeedsUpdate(true);
       }
     } else {


### PR DESCRIPTION
If the CLI isn't running a version that exposes the version on health endpoint, ignore the blocking (until next CLI is released).