### PR TITLE
fix: Support JSONC (comments) in VSCode settings.json

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -341,6 +341,7 @@
         "content-type": "^1.0.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "jsonc-parser": "^3.3.1",
         "lodash": "^4.17.21",
         "node-machine-id": "^1.1.12",
         "ora": "^8.2.0",
@@ -2151,7 +2152,7 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
-    "jsonc-parser": ["jsonc-parser@2.2.1", "", {}, "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="],
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
@@ -3256,6 +3257,8 @@
     "@segment/analytics-node/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
     "@stoplight/better-ajv-errors/leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
+
+    "@stoplight/json/jsonc-parser": ["jsonc-parser@2.2.1", "", {}, "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="],
 
     "@stoplight/json/safe-stable-stringify": ["safe-stable-stringify@1.1.1", "", {}, "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="],
 

--- a/packages/client-configurator/src/types.ts
+++ b/packages/client-configurator/src/types.ts
@@ -1,5 +1,8 @@
 import { AppError, ErrorCode } from "@director.run/utilities/error";
-import { readJSONFile } from "@director.run/utilities/json";
+import {
+  readJSONFile,
+  type ReadJSONFileOptions,
+} from "@director.run/utilities/json";
 import { type Logger, getLogger } from "@director.run/utilities/logger";
 
 export type InstallerResult = {
@@ -26,6 +29,14 @@ export abstract class AbstractClient<T> {
     this.logger = getLogger(`client-configurator/${this.name}`);
   }
 
+  /**
+   * Override this method to specify custom options for reading the config file.
+   * For example, VSCode settings.json supports comments (JSONC format).
+   */
+  protected getReadJSONFileOptions(): ReadJSONFileOptions | undefined {
+    return undefined;
+  }
+
   protected async initialize() {
     if (this.isInitialized && this.config) {
       return;
@@ -47,7 +58,10 @@ export abstract class AbstractClient<T> {
     }
 
     try {
-      this.config = await readJSONFile<T>(this.configPath);
+      this.config = await readJSONFile<T>(
+        this.configPath,
+        this.getReadJSONFileOptions(),
+      );
       this.isInitialized = true;
     } catch (error) {
       // check if the error is a syntax error

--- a/packages/client-configurator/src/vscode.test.ts
+++ b/packages/client-configurator/src/vscode.test.ts
@@ -1,12 +1,19 @@
+import fs from "node:fs/promises";
 import { readJSONFile } from "@director.run/utilities/json";
-import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   createConfigFile,
   createTestClient,
   deleteConfigFile,
+  getConfigPath,
 } from "./test/fixtures";
 
 describe(`vscode config`, () => {
+  // Cleanup after each test to avoid file conflicts with integration tests
+  afterEach(async () => {
+    await deleteConfigFile("vscode");
+  });
+
   describe("incomplete config", () => {
     const incompleteConfig = {
       foo: "bar",
@@ -16,10 +23,6 @@ describe(`vscode config`, () => {
         target: "vscode",
         config: incompleteConfig,
       });
-    });
-
-    afterAll(async () => {
-      await deleteConfigFile("vscode");
     });
 
     test("should initialize the config if it is missing the mcp.servers", async () => {
@@ -35,6 +38,38 @@ describe(`vscode config`, () => {
           servers: {},
         },
       });
+    });
+  });
+
+  describe("JSONC support (JSON with comments)", () => {
+    const configPath = getConfigPath("vscode");
+
+    beforeEach(async () => {
+      // Write a config file with comments (JSONC format)
+      const jsoncContent = `{
+  // This is a comment
+  "editor.fontSize": 14,
+  /* Multi-line
+     comment */
+  "mcp": {
+    "servers": {}
+  }
+}`;
+      await fs.writeFile(configPath, jsoncContent);
+    });
+
+    test("should parse settings.json files with comments", async () => {
+      const installer = createTestClient("vscode");
+
+      // Should not throw when parsing a file with comments
+      expect(await installer.isInstalled("any")).toBe(false);
+
+      // Should preserve other settings
+      expect(await readJSONFile(installer.configPath, { jsonc: true })).toEqual(
+        expect.objectContaining({
+          "editor.fontSize": 14,
+        }),
+      );
     });
   });
 });

--- a/packages/client-configurator/src/vscode.ts
+++ b/packages/client-configurator/src/vscode.ts
@@ -3,7 +3,10 @@ import path from "node:path";
 import { isTest } from "@director.run/utilities/env";
 import { ErrorCode } from "@director.run/utilities/error";
 import { AppError } from "@director.run/utilities/error";
-import { writeJSONFile } from "@director.run/utilities/json";
+import {
+  writeJSONFile,
+  type ReadJSONFileOptions,
+} from "@director.run/utilities/json";
 import { os, App } from "@director.run/utilities/os/index";
 import {
   AbstractClient,
@@ -25,6 +28,14 @@ export class VSCodeInstaller extends AbstractClient<VSCodeConfig> {
       name: "vscode",
       configKeyPrefix: params.configKeyPrefix,
     });
+  }
+
+  /**
+   * VSCode settings.json supports comments (JSONC format).
+   * We need to use the JSONC parser to handle this.
+   */
+  protected getReadJSONFileOptions(): ReadJSONFileOptions {
+    return { jsonc: true };
   }
 
   protected async initialize() {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.24.3",
+    "jsonc-parser": "^3.3.1",
     "@segment/analytics-node": "^2.3.0",
     "@t3-oss/env-core": "^0.12.0",
     "@trpc/client": "^11.0.2",

--- a/packages/utilities/src/json.ts
+++ b/packages/utilities/src/json.ts
@@ -1,17 +1,54 @@
 import fs, { type PathLike } from "node:fs";
 import { existsSync } from "node:fs";
 import { dirname } from "node:path";
+import {
+  parse as parseJsonc,
+  type ParseError,
+  printParseErrorCode,
+} from "jsonc-parser";
 import { AppError, ErrorCode } from "./error";
+
+export type ReadJSONFileOptions = {
+  /**
+   * If true, parse as JSONC (JSON with comments).
+   * Use this for VSCode settings and other files that may contain comments.
+   */
+  jsonc?: boolean;
+};
 
 export async function readJSONFile<T = unknown>(
   filePath: PathLike,
+  options?: ReadJSONFileOptions,
 ): Promise<T> {
   if (!existsSync(filePath)) {
     throw new AppError(ErrorCode.NOT_FOUND, `file not found at: ${filePath}`);
   }
 
   const buffer = await fs.promises.readFile(filePath);
-  let data = new TextDecoder().decode(buffer);
+  const data = new TextDecoder().decode(buffer);
+
+  if (options?.jsonc) {
+    const errors: ParseError[] = [];
+    const result = parseJsonc(data, errors);
+
+    // Throw an error if there are fatal parse errors
+    // We only throw for critical errors like invalid tokens or missing values
+    const fatalErrors = errors.filter(
+      (e) =>
+        e.error === 1 || // InvalidSymbol
+        e.error === 7, // EndOfFileExpected (incomplete JSON)
+    );
+
+    if (fatalErrors.length > 0) {
+      const firstError = fatalErrors[0];
+      throw new SyntaxError(
+        `${printParseErrorCode(firstError.error)} at offset ${firstError.offset}`,
+      );
+    }
+
+    return result as T;
+  }
+
   return JSON.parse(data) as T;
 }
 


### PR DESCRIPTION
## Summary
Fixes #458

VSCode `settings.json` supports JSONC format (JSON with Comments), but the CLI was using `JSON.parse()` which fails on files containing comments like:

```jsonc
{
  // This is a comment
  "editor.fontSize": 14,
  /* Multi-line comment */
  "mcp": { "servers": {} }
}
```

## Changes
- Add `jsonc-parser` dependency to utilities package (official VSCode JSONC parser)
- Add optional `jsonc` flag to `readJSONFile()` for JSONC parsing
- Add `getReadJSONFileOptions()` method to `AbstractClient` for subclasses to specify custom parsing options
- `VSCodeInstaller` now uses JSONC parsing for `settings.json`
- Add test for parsing VSCode settings with comments
- Fatal parse errors (invalid tokens, incomplete JSON) still throw `SyntaxError`

## Testing
All existing tests pass + new test for JSONC parsing.

```bash
cd packages/client-configurator && npx vitest run
# 117 passed
```