### PR TITLE
Add a comprehensive kitchen-sink Storybook for the design system

### DIFF
--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -1,8 +1,26 @@
-import type { Preview } from "@storybook/react-vite";
+import type { Decorator, Preview } from "@storybook/react-vite";
+import { useEffect } from "react";
+import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from "storybook/viewport";
 import "../src/fonts.css";
 import "../src/globals.css";
 
+const withDarkMode: Decorator = (Story, context) => {
+  const raw = context.globals.darkMode;
+  const darkMode = raw === true || raw === "true";
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle("dark", darkMode);
+    return () => {
+      root.classList.remove("dark");
+    };
+  }, [darkMode]);
+
+  return <Story />;
+};
+
 const preview: Preview = {
+  decorators: [withDarkMode],
   parameters: {
     controls: {
       matchers: {
@@ -22,6 +40,12 @@ const preview: Preview = {
           value: "#1a1a1a",
         },
       ],
+    },
+    viewport: {
+      options: {
+        ...MINIMAL_VIEWPORTS,
+        ...INITIAL_VIEWPORTS,
+      },
     },
   },
   globalTypes: {

--- a/apps/studio/cspell.json
+++ b/apps/studio/cspell.json
@@ -8,5 +8,12 @@
     "**/dist/**",
     "dist-storybook/**"
   ],
-  "words": ["streamable", "waitlist"]
+  "words": [
+    "hackernews",
+    "modelcontextprotocol",
+    "streamable",
+    "summarise",
+    "triaging",
+    "waitlist"
+  ]
 }

--- a/apps/studio/src/kitchen-sink/components-all.stories.tsx
+++ b/apps/studio/src/kitchen-sink/components-all.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ContentGallery } from "./lib/gallery/content-gallery";
+import { FormsGallery } from "./lib/gallery/forms-gallery";
+import { OverlaysGallery } from "./lib/gallery/overlays-gallery";
+import { PrimitivesGallery } from "./lib/gallery/primitives-gallery";
+
+/**
+ * Everything at once: all four galleries stacked on a single scrollable page,
+ * so the totality of the design system can be examined without switching
+ * stories.
+ */
+function AllComponents() {
+  return (
+    <div className="flex flex-col gap-y-20 p-8">
+      <PrimitivesGallery />
+      <FormsGallery />
+      <OverlaysGallery />
+      <ContentGallery />
+    </div>
+  );
+}
+
+const meta = {
+  title: "kitchen-sink/components/all-components",
+  component: AllComponents,
+  parameters: {
+    layout: "fullscreen",
+    chromatic: { disableSnapshot: true },
+  },
+} satisfies Meta<typeof AllComponents>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/studio/src/kitchen-sink/components-content.stories.tsx
+++ b/apps/studio/src/kitchen-sink/components-content.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ContentGallery } from "./lib/gallery/content-gallery";
+
+/**
+ * Layout and content components — containers, sections, lists, tabs, menus,
+ * breadcrumbs, markdown, JSON schema and the domain cards built on them.
+ */
+const meta = {
+  title: "kitchen-sink/components/content",
+  component: ContentGallery,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof ContentGallery>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/studio/src/kitchen-sink/components-forms.stories.tsx
+++ b/apps/studio/src/kitchen-sink/components-forms.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { FormsGallery } from "./lib/gallery/forms-gallery";
+
+/**
+ * Form building blocks and the higher-level forms composed from them, with
+ * validation and submitting states.
+ */
+const meta = {
+  title: "kitchen-sink/components/forms",
+  component: FormsGallery,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof FormsGallery>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/studio/src/kitchen-sink/components-overlays.stories.tsx
+++ b/apps/studio/src/kitchen-sink/components-overlays.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { OverlaysGallery } from "./lib/gallery/overlays-gallery";
+
+/**
+ * Overlay components — dialogs, alert dialogs, sheets, popovers, dropdown
+ * menus and toasts — each with a trigger and, where useful, an open variant.
+ */
+const meta = {
+  title: "kitchen-sink/components/overlays",
+  component: OverlaysGallery,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof OverlaysGallery>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/studio/src/kitchen-sink/components-primitives.stories.tsx
+++ b/apps/studio/src/kitchen-sink/components-primitives.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PrimitivesGallery } from "./lib/gallery/primitives-gallery";
+
+/**
+ * Every low-level UI primitive (buttons, badges, inputs, typography, loaders,
+ * icons) with its variants, sizes and states on one page.
+ */
+const meta = {
+  title: "kitchen-sink/components/primitives",
+  component: PrimitivesGallery,
+  parameters: {
+    layout: "padded",
+    // ScrambleText and Loader animate via setInterval — skip visual snapshots.
+    chromatic: { disableSnapshot: true },
+  },
+} satisfies Meta<typeof PrimitivesGallery>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/studio/src/kitchen-sink/kitchen-sink-app.stories.tsx
+++ b/apps/studio/src/kitchen-sink/kitchen-sink-app.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { emptyKitchenSinkPlaybook } from "./lib/fixtures";
+import { KitchenSinkApp } from "./lib/kitchen-sink-app";
+
+/**
+ * The flagship kitchen-sink story: a fully interactive mock of the Director
+ * Studio app. The sidebar, menus, sheets, dialogs and toasts are all live and
+ * driven by in-memory state — click around to move between playbooks, the
+ * registry library, settings and onboarding.
+ */
+const meta = {
+  title: "kitchen-sink/app",
+  component: KitchenSinkApp,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof KitchenSinkApp>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Desktop: Story = {};
+
+export const Mobile: Story = {
+  globals: { viewport: { value: "mobile2", isRotated: false } },
+};
+
+export const MobileSmall: Story = {
+  globals: { viewport: { value: "mobile1", isRotated: false } },
+};
+
+export const Tablet: Story = {
+  globals: { viewport: { value: "tablet", isRotated: false } },
+};
+
+export const SidebarLoading: Story = {
+  args: { sidebarLoading: true },
+  parameters: { chromatic: { disableSnapshot: true } },
+};
+
+export const LoadingStates: Story = {
+  args: { pageState: "loading", sidebarLoading: true },
+  parameters: { chromatic: { disableSnapshot: true } },
+};
+
+export const EmptyStates: Story = {
+  args: { initialPlaybooks: [emptyKitchenSinkPlaybook()] },
+};
+
+export const ErrorState: Story = {
+  args: { pageState: "error" },
+};
+
+export const Onboarding: Story = {
+  args: { initialRoute: { name: "get-started" } },
+};
+
+export const DarkMode: Story = {
+  globals: { darkMode: true },
+};

--- a/apps/studio/src/kitchen-sink/lib/fixtures.ts
+++ b/apps/studio/src/kitchen-sink/lib/fixtures.ts
@@ -1,6 +1,10 @@
 import type { ConnectionInfo } from "@director.run/design/components/playbooks-clients/playbook-section-connect.tsx";
 import type { PlaybookDetail } from "@director.run/design/components/types.ts";
 
+/** Shared fake-latency helper for the mock routes' async handlers. */
+export const delay = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 /**
  * Three named playbooks with a deliberate spread of connection statuses
  * (connected / disconnected / unauthorized / error) so every server state in
@@ -131,6 +135,7 @@ export function kitchenSinkPlaybooks(): PlaybookDetail[] {
           connectionInfo: {
             status: "connected",
             lastConnectedAt: new Date("2026-06-02T14:05:00.000Z"),
+            isAuthenticated: true,
           },
         },
       ],

--- a/apps/studio/src/kitchen-sink/lib/fixtures.ts
+++ b/apps/studio/src/kitchen-sink/lib/fixtures.ts
@@ -1,0 +1,174 @@
+import type { ConnectionInfo } from "@director.run/design/components/playbooks-clients/playbook-section-connect.tsx";
+import type { PlaybookDetail } from "@director.run/design/components/types.ts";
+
+/**
+ * Three named playbooks with a deliberate spread of connection statuses
+ * (connected / disconnected / unauthorized / error) so every server state in
+ * the design system is visible across the mock app.
+ */
+export function kitchenSinkPlaybooks(): PlaybookDetail[] {
+  return [
+    {
+      id: "incident-response",
+      name: "Incident Response",
+      description: "On-call tooling for triaging and resolving incidents.",
+      userId: "kitchen-sink-user",
+      prompts: [
+        {
+          name: "triage",
+          title: "Triage checklist",
+          body: "Summarise the incident, list impacted services and propose next steps.",
+        },
+        {
+          name: "postmortem",
+          title: "Draft postmortem",
+          body: "Write a blameless postmortem from the incident timeline.",
+        },
+      ],
+      servers: [
+        {
+          type: "stdio",
+          name: "hackernews",
+          disabled: false,
+          command: "uvx",
+          args: ["--from", "git+https://github.com/erithwik/mcp-hn", "mcp-hn"],
+          env: {},
+          connectionInfo: {
+            status: "connected",
+            lastConnectedAt: new Date("2026-06-01T09:30:00.000Z"),
+          },
+        },
+        {
+          type: "http",
+          name: "sentry",
+          disabled: false,
+          url: "https://mcp.sentry.dev/mcp",
+          connectionInfo: {
+            status: "error",
+            lastErrorMessage: "Connection refused (ECONNREFUSED)",
+          },
+        },
+        {
+          type: "stdio",
+          name: "filesystem",
+          disabled: true,
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+          env: {},
+          connectionInfo: {
+            status: "disconnected",
+          },
+        },
+      ],
+      paths: {
+        streamable: "/incident-response/mcp",
+      },
+    },
+    {
+      id: "data-pipeline",
+      name: "Data Pipeline",
+      description: "Servers for building and monitoring ETL workflows.",
+      userId: "kitchen-sink-user",
+      prompts: [
+        {
+          name: "explain-schema",
+          title: "Explain schema",
+          body: "Describe the tables and relationships in the warehouse.",
+        },
+      ],
+      servers: [
+        {
+          type: "http",
+          name: "notion",
+          disabled: false,
+          url: "https://mcp.notion.com/mcp",
+          connectionInfo: {
+            status: "unauthorized",
+            lastErrorMessage: "unauthorized, please re-authenticate",
+          },
+        },
+        {
+          type: "stdio",
+          name: "fetch",
+          disabled: false,
+          command: "uvx",
+          args: ["mcp-server-fetch"],
+          env: {},
+          connectionInfo: {
+            status: "connected",
+            lastConnectedAt: new Date("2026-06-01T08:15:00.000Z"),
+          },
+        },
+      ],
+      paths: {
+        streamable: "/data-pipeline/mcp",
+      },
+    },
+    {
+      id: "personal-research",
+      name: "Personal Research",
+      description: "A grab-bag of servers for everyday research tasks.",
+      userId: "kitchen-sink-user",
+      prompts: [],
+      servers: [
+        {
+          type: "stdio",
+          name: "hackernews",
+          disabled: false,
+          command: "uvx",
+          args: ["--from", "git+https://github.com/erithwik/mcp-hn", "mcp-hn"],
+          env: {},
+          connectionInfo: {
+            status: "connected",
+            lastConnectedAt: new Date("2026-06-02T14:00:00.000Z"),
+          },
+        },
+        {
+          type: "http",
+          name: "github",
+          disabled: false,
+          url: "https://api.githubcopilot.com/mcp/",
+          connectionInfo: {
+            status: "connected",
+            lastConnectedAt: new Date("2026-06-02T14:05:00.000Z"),
+          },
+        },
+      ],
+      paths: {
+        streamable: "/personal-research/mcp",
+      },
+    },
+  ];
+}
+
+/** A single playbook with no servers or prompts, for empty-state variants. */
+export function emptyKitchenSinkPlaybook(): PlaybookDetail {
+  return {
+    id: "empty-playbook",
+    name: "Empty Playbook",
+    description: "A brand new playbook with nothing added yet.",
+    userId: "kitchen-sink-user",
+    prompts: [],
+    servers: [],
+    paths: {
+      streamable: "/empty-playbook/mcp",
+    },
+  };
+}
+
+/** Connection details rendered by the "Connect to Playbook" sidebar. */
+export function kitchenSinkConnectionInfo(playbookId: string): ConnectionInfo {
+  return {
+    playbookId,
+    apiKey: "dk_live_abc123def456ghi789jkl012",
+    streamableUrl: `https://gateway.director.run/mcp/${playbookId}`,
+  };
+}
+
+/** API-key summary shown on the settings page. */
+export const kitchenSinkApiKey = {
+  id: "default",
+  keyPrefix: "dk_live_",
+  createdAt: "2026-05-01T12:00:00.000Z",
+  lastUsedAt: "2026-06-02T14:05:00.000Z" as string | null,
+};

--- a/apps/studio/src/kitchen-sink/lib/gallery/content-gallery.tsx
+++ b/apps/studio/src/kitchen-sink/lib/gallery/content-gallery.tsx
@@ -1,0 +1,215 @@
+import { MCPLinkCard } from "@director.run/design/components/mcp-servers/mcp-link-card.tsx";
+import { MCPLinkCardList } from "@director.run/design/components/mcp-servers/mcp-link-card.tsx";
+import { PlaybookTargetPropertyList } from "@director.run/design/components/mcp-servers/playbook-target-property-list.tsx";
+import { RegistryEntryPropertyList } from "@director.run/design/components/registry/registry-entry-property-list.tsx";
+import { RegistryParameters } from "@director.run/design/components/registry/registry-parameters.tsx";
+import {
+  SplitView,
+  SplitViewMain,
+  SplitViewSide,
+} from "@director.run/design/components/split-view.tsx";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@director.run/design/components/ui/breadcrumb.tsx";
+import { Container } from "@director.run/design/components/ui/container.tsx";
+import {
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateTitle,
+} from "@director.run/design/components/ui/empty-state.tsx";
+import { JSONSchema } from "@director.run/design/components/ui/json-schema.tsx";
+import {
+  List,
+  ListItem,
+  ListItemDescription,
+  ListItemDetails,
+  ListItemTitle,
+} from "@director.run/design/components/ui/list.tsx";
+import { Markdown } from "@director.run/design/components/ui/markdown.tsx";
+import { SimpleMarkdown } from "@director.run/design/components/ui/markdown.tsx";
+import {
+  Menu,
+  MenuItem,
+  MenuItemLabel,
+  MenuLabel,
+} from "@director.run/design/components/ui/menu.tsx";
+import {
+  Section,
+  SectionDescription,
+  SectionHeader,
+  SectionSeparator,
+  SectionTitle,
+} from "@director.run/design/components/ui/section.tsx";
+import { Tab, Tabs } from "@director.run/design/components/ui/tabs.tsx";
+import { mockPlaybookTarget } from "@director.run/design/test/fixtures/playbook/playbook-target.ts";
+import { mockRegistryEntryList } from "@director.run/design/test/fixtures/registry/entry-list.ts";
+import { mockRegistryEntry } from "@director.run/design/test/fixtures/registry/entry.ts";
+import { GallerySection } from "./gallery-section";
+
+const CONTAINER_SIZES = ["sm", "md", "lg"] as const;
+
+const sampleMarkdown = [
+  "## Markdown",
+  "",
+  "Supports **bold**, _italic_, `code` and lists:",
+  "",
+  "- First item",
+  "- Second item",
+].join("\n");
+
+const sampleSchema = {
+  type: "object",
+  required: ["query"],
+  properties: {
+    query: { type: "string", description: "The search query" },
+    limit: { type: "number", description: "Maximum results", default: 10 },
+    includeArchived: {
+      type: "boolean",
+      description: "Include archived items",
+    },
+  },
+};
+
+export function ContentGallery() {
+  return (
+    <div className="flex flex-col gap-y-12">
+      <GallerySection
+        title="Containers"
+        description="Width-constraining wrappers by size."
+      >
+        <div className="flex flex-col gap-y-2">
+          {CONTAINER_SIZES.map((size) => (
+            <Container key={size} size={size}>
+              <div className="rounded-lg border border-accent bg-accent-subtle p-3 text-center text-fg-subtle text-xs">
+                Container size="{size}"
+              </div>
+            </Container>
+          ))}
+        </div>
+      </GallerySection>
+
+      <GallerySection
+        title="Sections, lists & empty state"
+        description="The building blocks for most pages."
+      >
+        <Section>
+          <SectionHeader>
+            <SectionTitle variant="h2" asChild>
+              <h3>Section title</h3>
+            </SectionTitle>
+            <SectionDescription>
+              A section groups related content under a heading.
+            </SectionDescription>
+          </SectionHeader>
+          <List>
+            <ListItem>
+              <ListItemDetails>
+                <ListItemTitle>List item</ListItemTitle>
+                <ListItemDescription>
+                  With a title and a description.
+                </ListItemDescription>
+              </ListItemDetails>
+            </ListItem>
+            <ListItem onClick={() => undefined}>
+              <ListItemDetails>
+                <ListItemTitle>Clickable item</ListItemTitle>
+                <ListItemDescription>
+                  Hover to see the interactive treatment.
+                </ListItemDescription>
+              </ListItemDetails>
+            </ListItem>
+          </List>
+          <SectionSeparator />
+          <EmptyState>
+            <EmptyStateTitle>No items</EmptyStateTitle>
+            <EmptyStateDescription>This list is empty.</EmptyStateDescription>
+          </EmptyState>
+        </Section>
+      </GallerySection>
+
+      <GallerySection title="Navigation">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/">Library</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>GitHub</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+
+        <Tabs default="one">
+          <Tab
+            id="one"
+            label="First tab"
+            content={<p className="text-fg-subtle text-sm">First panel.</p>}
+          />
+          <Tab
+            id="two"
+            label="Second tab"
+            content={<p className="text-fg-subtle text-sm">Second panel.</p>}
+          />
+        </Tabs>
+
+        <div className="max-w-[220px]">
+          <Menu>
+            <MenuLabel label="Playbooks" />
+            <MenuItem data-state="active">
+              <MenuItemLabel>Active item</MenuItemLabel>
+            </MenuItem>
+            <MenuItem>
+              <MenuItemLabel>Another item</MenuItemLabel>
+            </MenuItem>
+          </Menu>
+        </div>
+      </GallerySection>
+
+      <GallerySection title="Rich content">
+        <div className="flex flex-col gap-y-6">
+          <Markdown>{sampleMarkdown}</Markdown>
+          <SimpleMarkdown>
+            {"Inline **bold**, _italic_ and `code` only."}
+          </SimpleMarkdown>
+          <JSONSchema schema={sampleSchema} />
+        </div>
+      </GallerySection>
+
+      <GallerySection
+        title="Domain cards & property lists"
+        description="Composite components used across playbooks and the registry."
+      >
+        <MCPLinkCardList>
+          {mockRegistryEntryList.slice(0, 4).map((entry) => (
+            <MCPLinkCard
+              key={entry.id}
+              entry={entry}
+              onClick={() => undefined}
+            />
+          ))}
+        </MCPLinkCardList>
+        <RegistryEntryPropertyList entry={mockRegistryEntry} />
+        <RegistryParameters parameters={mockRegistryEntry.parameters} />
+        <PlaybookTargetPropertyList target={mockPlaybookTarget} />
+        <SplitView>
+          <SplitViewMain>
+            <div className="rounded-lg border border-accent bg-accent-subtle p-4 text-fg-subtle text-sm">
+              Split view — main column
+            </div>
+          </SplitViewMain>
+          <SplitViewSide>
+            <div className="rounded-lg border border-accent bg-accent-subtle p-4 text-fg-subtle text-sm">
+              Side column (hidden below lg)
+            </div>
+          </SplitViewSide>
+        </SplitView>
+      </GallerySection>
+    </div>
+  );
+}

--- a/apps/studio/src/kitchen-sink/lib/gallery/forms-gallery.tsx
+++ b/apps/studio/src/kitchen-sink/lib/gallery/forms-gallery.tsx
@@ -1,0 +1,127 @@
+import { GetStartedPlaybookForm } from "@director.run/design/components/get-started/get-started-playbook-form.tsx";
+import { playbookSchema } from "@director.run/design/components/get-started/get-started-playbook-form.tsx";
+import { PlaybookForm } from "@director.run/design/components/playbooks/playbook-form.tsx";
+import { RegistryInstallForm } from "@director.run/design/components/registry/registry-install-form.tsx";
+import { Button } from "@director.run/design/components/ui/button.tsx";
+import { FormWithSchema } from "@director.run/design/components/ui/form.tsx";
+import { HiddenField } from "@director.run/design/components/ui/form/hidden-field.tsx";
+import { InputField } from "@director.run/design/components/ui/form/input-field.tsx";
+import { SelectNativeField } from "@director.run/design/components/ui/form/select-native-field.tsx";
+import { TextareaField } from "@director.run/design/components/ui/form/textarea-field.tsx";
+import { Toaster, toast } from "@director.run/design/components/ui/toast.tsx";
+import { useZodForm } from "@director.run/design/hooks/use-zod-form.tsx";
+import { mockRegistryEntry } from "@director.run/design/test/fixtures/registry/entry.ts";
+import { z } from "zod";
+import { kitchenSinkPlaybooks } from "../fixtures";
+import { GallerySection } from "./gallery-section";
+
+const demoSchema = z.object({
+  name: z.string().trim().min(1, "Required"),
+  bio: z.string().optional(),
+  role: z.string(),
+  source: z.string(),
+});
+
+const demoDefaults = { name: "", bio: "", role: "admin", source: "gallery" };
+
+const submitted = () =>
+  toast({ title: "Submitted", description: "The form was submitted." });
+
+export function FormsGallery() {
+  const onboardingForm = useZodForm({
+    schema: playbookSchema,
+    defaultValues: { name: "", description: "A playbook for getting started" },
+  });
+
+  return (
+    <div className="flex flex-col gap-y-12">
+      <GallerySection
+        title="Form fields"
+        description="Field wrappers built on react-hook-form + zod. Submit empty to see validation."
+      >
+        <div className="max-w-md">
+          <FormWithSchema
+            schema={demoSchema}
+            defaultValues={demoDefaults}
+            onSubmit={() => {
+              submitted();
+            }}
+          >
+            <div className="flex flex-col gap-y-6">
+              <InputField name="name" label="Name" placeholder="Ada Lovelace" />
+              <TextareaField
+                name="bio"
+                label="Bio"
+                helperLabel="Optional"
+                placeholder="A short bio"
+              />
+              <SelectNativeField name="role" label="Role">
+                <option value="admin">Admin</option>
+                <option value="member">Member</option>
+              </SelectNativeField>
+              <HiddenField name="source" />
+              <Button type="submit">Submit</Button>
+            </div>
+          </FormWithSchema>
+        </div>
+      </GallerySection>
+
+      <GallerySection
+        title="Playbook form"
+        description="One component powering both create and edit."
+      >
+        <div className="grid max-w-3xl gap-8 md:grid-cols-2">
+          <PlaybookForm
+            onSubmit={() => {
+              submitted();
+              return Promise.resolve();
+            }}
+          >
+            <Button>Create playbook</Button>
+          </PlaybookForm>
+          <PlaybookForm
+            defaultValues={{
+              name: "Incident Response",
+              description: "On-call tooling for triaging incidents.",
+            }}
+            onSubmit={() => {
+              submitted();
+              return Promise.resolve();
+            }}
+          >
+            <Button>Save changes</Button>
+          </PlaybookForm>
+        </div>
+      </GallerySection>
+
+      <GallerySection
+        title="Registry install form"
+        description="Renders required and password parameters from a registry entry."
+      >
+        <div className="max-w-md">
+          <RegistryInstallForm
+            registryEntry={mockRegistryEntry}
+            playbooks={kitchenSinkPlaybooks()}
+            onSubmit={() => {
+              submitted();
+            }}
+          />
+        </div>
+      </GallerySection>
+
+      <GallerySection title="Onboarding playbook form">
+        <div className="max-w-md">
+          <GetStartedPlaybookForm
+            form={onboardingForm}
+            isPending={false}
+            onSubmit={() => {
+              submitted();
+            }}
+          />
+        </div>
+      </GallerySection>
+
+      <Toaster />
+    </div>
+  );
+}

--- a/apps/studio/src/kitchen-sink/lib/gallery/gallery-section.tsx
+++ b/apps/studio/src/kitchen-sink/lib/gallery/gallery-section.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+
+/**
+ * Presentational shells that give every gallery a consistent, labelled layout.
+ * A `GallerySection` is a titled block; a `GalleryRow` lays out a labelled row
+ * of component variants.
+ */
+export function GallerySection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-y-5">
+      <div className="flex flex-col gap-y-1">
+        <h2 className="font-medium text-fg text-lg">{title}</h2>
+        {description && (
+          <p className="max-w-prose text-fg-subtle text-sm">{description}</p>
+        )}
+      </div>
+      <div className="flex flex-col gap-y-6">{children}</div>
+    </section>
+  );
+}
+
+export function GalleryRow({
+  label,
+  children,
+}: {
+  label?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-y-2">
+      {label && (
+        <p className="font-mono text-fg-subtle text-xs uppercase tracking-wide">
+          {label}
+        </p>
+      )}
+      <div className="flex flex-row flex-wrap items-center gap-3">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/studio/src/kitchen-sink/lib/gallery/overlays-gallery.tsx
+++ b/apps/studio/src/kitchen-sink/lib/gallery/overlays-gallery.tsx
@@ -1,0 +1,231 @@
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@director.run/design/components/ui/alert-dialog.tsx";
+import { Button } from "@director.run/design/components/ui/button.tsx";
+import { ConfirmDialog } from "@director.run/design/components/ui/confirm-dialog.tsx";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@director.run/design/components/ui/dialog.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@director.run/design/components/ui/dropdown-menu.tsx";
+import {
+  MenuItemIcon,
+  MenuItemLabel,
+} from "@director.run/design/components/ui/menu.tsx";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@director.run/design/components/ui/popover.tsx";
+import {
+  Sheet,
+  SheetActions,
+  SheetBody,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@director.run/design/components/ui/sheet.tsx";
+import { Toaster, toast } from "@director.run/design/components/ui/toast.tsx";
+import { GearIcon, SignOutIcon, TrashIcon } from "@phosphor-icons/react";
+import { GalleryRow, GallerySection } from "./gallery-section";
+
+export function OverlaysGallery() {
+  return (
+    <div className="flex flex-col gap-y-12">
+      <GallerySection
+        title="Dialogs & sheets"
+        description="Click a trigger to open each overlay."
+      >
+        <GalleryRow label="triggers">
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button>Open dialog</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Dialog title</DialogTitle>
+                <DialogDescription>
+                  A modal dialog with a header, body and footer.
+                </DialogDescription>
+              </DialogHeader>
+              <p className="text-fg-subtle text-sm">Body content goes here.</p>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button variant="secondary">Cancel</Button>
+                </DialogClose>
+                <DialogClose asChild>
+                  <Button>Confirm</Button>
+                </DialogClose>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="secondary">Open alert dialog</Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This action cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <Button>Continue</Button>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+
+          <ConfirmDialog
+            title="Delete item?"
+            description="This action cannot be undone."
+            onConfirm={() =>
+              toast({ title: "Deleted", description: "The item was deleted." })
+            }
+          >
+            <Button variant="secondary">Confirm dialog</Button>
+          </ConfirmDialog>
+
+          <Sheet>
+            <SheetTrigger asChild>
+              <Button>Open sheet</Button>
+            </SheetTrigger>
+            <SheetContent>
+              <SheetActions />
+              <SheetBody>
+                <SheetHeader>
+                  <SheetTitle>Sheet title</SheetTitle>
+                  <SheetDescription>
+                    A side sheet for forms and detail views.
+                  </SheetDescription>
+                </SheetHeader>
+                <p className="text-fg-subtle text-sm">Body content.</p>
+              </SheetBody>
+            </SheetContent>
+          </Sheet>
+        </GalleryRow>
+      </GallerySection>
+
+      <GallerySection title="Menus & popovers">
+        <GalleryRow label="triggers">
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="secondary">Open popover</Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-64">
+              <p className="text-fg-subtle text-sm">
+                Popover content anchored to its trigger.
+              </p>
+            </PopoverContent>
+          </Popover>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost">Open menu</Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuGroup>
+                <DropdownMenuItem>
+                  <MenuItemIcon>
+                    <GearIcon />
+                  </MenuItemIcon>
+                  <MenuItemLabel>Settings</MenuItemLabel>
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <MenuItemIcon>
+                    <SignOutIcon />
+                  </MenuItemIcon>
+                  <MenuItemLabel>Log out</MenuItemLabel>
+                </DropdownMenuItem>
+              </DropdownMenuGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuGroup>
+                <DropdownMenuItem>
+                  <MenuItemIcon>
+                    <TrashIcon />
+                  </MenuItemIcon>
+                  <MenuItemLabel>Delete</MenuItemLabel>
+                </DropdownMenuItem>
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </GalleryRow>
+      </GallerySection>
+
+      <GallerySection
+        title="Toasts"
+        description="Transient notifications rendered by the Toaster."
+      >
+        <GalleryRow label="triggers">
+          <Button
+            onClick={() =>
+              toast({
+                title: "Saved",
+                description: "Your changes were saved.",
+              })
+            }
+          >
+            Success
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() =>
+              toast({
+                title: "Heads up",
+                description: "Something needs your attention.",
+              })
+            }
+          >
+            Info
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() =>
+              toast({
+                title: "Copied to clipboard",
+                description:
+                  "A longer description that wraps onto multiple lines to show how the toast grows with its content.",
+              })
+            }
+          >
+            Long
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() =>
+              toast({ title: "Done", description: "Short and sweet." })
+            }
+          >
+            Short
+          </Button>
+        </GalleryRow>
+      </GallerySection>
+
+      <Toaster />
+    </div>
+  );
+}

--- a/apps/studio/src/kitchen-sink/lib/gallery/primitives-gallery.tsx
+++ b/apps/studio/src/kitchen-sink/lib/gallery/primitives-gallery.tsx
@@ -1,0 +1,179 @@
+import { McpLogo } from "@director.run/design/components/mcp-logo.tsx";
+import { ServerStatusBadge } from "@director.run/design/components/servers/server-status-badge.tsx";
+import {
+  Badge,
+  BadgeGroup,
+  BadgeIcon,
+  BadgeLabel,
+} from "@director.run/design/components/ui/badge.tsx";
+import { Button } from "@director.run/design/components/ui/button.tsx";
+import { Logo } from "@director.run/design/components/ui/icons/logo.tsx";
+import { MCPIcon } from "@director.run/design/components/ui/icons/mcp-icon.tsx";
+import { Input } from "@director.run/design/components/ui/input.tsx";
+import { Label } from "@director.run/design/components/ui/label.tsx";
+import { Loader } from "@director.run/design/components/ui/loader.tsx";
+import { ScrambleText } from "@director.run/design/components/ui/scramble-text.tsx";
+import { SelectNative } from "@director.run/design/components/ui/select-native.tsx";
+import { Separator } from "@director.run/design/components/ui/separator.tsx";
+import { Switch } from "@director.run/design/components/ui/switch.tsx";
+import { Textarea } from "@director.run/design/components/ui/textarea.tsx";
+import { textVariants } from "@director.run/design/components/ui/typography.tsx";
+import {
+  ArrowRightIcon,
+  CheckCircleIcon,
+  PlusIcon,
+  SealCheckIcon,
+} from "@phosphor-icons/react";
+import { kitchenSinkPlaybooks } from "../fixtures";
+import { GalleryRow, GallerySection } from "./gallery-section";
+
+const BUTTON_VARIANTS = ["default", "secondary", "inverse", "ghost"] as const;
+const BUTTON_SIZES = ["sm", "default", "lg"] as const;
+
+const statusServers = kitchenSinkPlaybooks()
+  .flatMap((playbook) => playbook.servers)
+  .filter(
+    (server, index, all) =>
+      all.findIndex(
+        (candidate) =>
+          candidate.connectionInfo?.status === server.connectionInfo?.status,
+      ) === index,
+  );
+
+export function PrimitivesGallery() {
+  return (
+    <div className="flex flex-col gap-y-12">
+      <GallerySection
+        title="Buttons"
+        description="Variants, sizes, icons and disabled state."
+      >
+        {BUTTON_VARIANTS.map((variant) => (
+          <GalleryRow key={variant} label={variant}>
+            {BUTTON_SIZES.map((size) => (
+              <Button key={size} variant={variant} size={size}>
+                {size}
+              </Button>
+            ))}
+            <Button variant={variant} size="icon">
+              <PlusIcon />
+            </Button>
+            <Button variant={variant} disabled>
+              disabled
+            </Button>
+          </GalleryRow>
+        ))}
+        <GalleryRow label="with icon / as link">
+          <Button>
+            <PlusIcon />
+            Add server
+          </Button>
+          <Button variant="secondary">
+            Continue
+            <ArrowRightIcon />
+          </Button>
+          <Button asChild>
+            <a href="/">Anchor button</a>
+          </Button>
+        </GalleryRow>
+      </GallerySection>
+
+      <GallerySection
+        title="Badges"
+        description="Status labels, with variants, icons and uppercase labels."
+      >
+        <GalleryRow label="variants">
+          <Badge>
+            <BadgeLabel>Default</BadgeLabel>
+          </Badge>
+          <Badge variant="success">
+            <BadgeLabel>Success</BadgeLabel>
+          </Badge>
+          <Badge variant="destructive">
+            <BadgeLabel>Destructive</BadgeLabel>
+          </Badge>
+        </GalleryRow>
+        <GalleryRow label="with icon / uppercase">
+          <Badge variant="success">
+            <BadgeIcon>
+              <SealCheckIcon />
+            </BadgeIcon>
+            <BadgeLabel uppercase>Official</BadgeLabel>
+          </Badge>
+          <Badge>
+            <BadgeIcon>
+              <CheckCircleIcon />
+            </BadgeIcon>
+            <BadgeLabel>Verified</BadgeLabel>
+          </Badge>
+        </GalleryRow>
+        <GalleryRow label="server status badge">
+          <BadgeGroup>
+            {statusServers.map((server) => (
+              <ServerStatusBadge key={server.name} server={server} />
+            ))}
+          </BadgeGroup>
+        </GalleryRow>
+      </GallerySection>
+
+      <GallerySection
+        title="Typography"
+        description="The text scale exposed through textVariants."
+      >
+        <div className="flex flex-col gap-y-2">
+          <span className={textVariants({ variant: "h1" })}>Heading 1</span>
+          <span className={textVariants({ variant: "h2" })}>Heading 2</span>
+          <span className={textVariants({ variant: "h3" })}>Heading 3</span>
+          <span className={textVariants({ variant: "h4" })}>Heading 4</span>
+          <span className={textVariants({ variant: "p" })}>
+            Body paragraph text used throughout the product.
+          </span>
+          <a className={textVariants({ variant: "inlineLink" })} href="/">
+            Inline link
+          </a>
+        </div>
+      </GallerySection>
+
+      <GallerySection
+        title="Form controls"
+        description="Bare inputs (see the Forms gallery for validated fields)."
+      >
+        <div className="flex max-w-md flex-col gap-y-4">
+          <div className="flex flex-col gap-y-1.5">
+            <Label htmlFor="gallery-input">Text input</Label>
+            <Input id="gallery-input" placeholder="Type here…" />
+          </div>
+          <Input defaultValue="With a value" />
+          <Input disabled placeholder="Disabled" />
+          <Textarea placeholder="Textarea…" />
+          <SelectNative defaultValue="http">
+            <option value="http">HTTP</option>
+            <option value="stdio">STDIO</option>
+          </SelectNative>
+          <GalleryRow label="switch">
+            <Switch defaultChecked />
+            <Switch />
+            <Switch defaultChecked disabled />
+            <Switch disabled />
+          </GalleryRow>
+          <Separator />
+        </div>
+      </GallerySection>
+
+      <GallerySection
+        title="Feedback & icons"
+        description="Loading indicators and brand marks."
+      >
+        <GalleryRow label="loaders">
+          <Loader />
+          <ScrambleText text="Loading" />
+        </GalleryRow>
+        <GalleryRow label="icons">
+          <Logo className="size-6" />
+          <MCPIcon />
+          <McpLogo src="/assets/github.svg" className="size-8" />
+          <McpLogo className="size-8" />
+        </GalleryRow>
+      </GallerySection>
+    </div>
+  );
+}

--- a/apps/studio/src/kitchen-sink/lib/kitchen-sink-app.tsx
+++ b/apps/studio/src/kitchen-sink/lib/kitchen-sink-app.tsx
@@ -1,0 +1,273 @@
+import { ChatToUs } from "@director.run/design/components/chat-to-us.tsx";
+import {
+  LayoutRoot,
+  LayoutView,
+} from "@director.run/design/components/layout/layout.tsx";
+import type { NavigationSection } from "@director.run/design/components/layout/navigation.tsx";
+import type {
+  MCPTool,
+  PlaybookDetail,
+} from "@director.run/design/components/types.ts";
+import {
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateTitle,
+} from "@director.run/design/components/ui/empty-state.tsx";
+import { MCPIcon } from "@director.run/design/components/ui/icons/mcp-icon.tsx";
+import { Toaster, toast } from "@director.run/design/components/ui/toast.tsx";
+import { mockTools } from "@director.run/design/test/fixtures/mcp/tools.js";
+import {
+  BookOpenTextIcon,
+  GearIcon,
+  GithubLogoIcon,
+  PlusIcon,
+} from "@phosphor-icons/react";
+import { useState } from "react";
+import { kitchenSinkConnectionInfo, kitchenSinkPlaybooks } from "./fixtures";
+import { GetStartedRoute } from "./routes/get-started-route";
+import { LibraryEntryRoute } from "./routes/library-entry-route";
+import { LibraryRoute } from "./routes/library-route";
+import { PlaybookDetailRoute } from "./routes/playbook-detail-route";
+import { PlaybookNewRoute } from "./routes/playbook-new-route";
+import { SettingsRoute } from "./routes/settings-route";
+import { TargetDetailRoute } from "./routes/target-detail-route";
+import type {
+  KitchenSinkAppProps,
+  KitchenSinkNavigate,
+  KitchenSinkRoute,
+} from "./types";
+
+const tools = mockTools() as MCPTool[];
+
+export function KitchenSinkApp({
+  initialRoute,
+  initialPlaybooks,
+  sidebarLoading = false,
+  pageState = "default",
+}: KitchenSinkAppProps) {
+  const [playbooks, setPlaybooks] = useState<PlaybookDetail[]>(
+    () => initialPlaybooks ?? kitchenSinkPlaybooks(),
+  );
+  const [route, setRoute] = useState<KitchenSinkRoute>(
+    () =>
+      initialRoute ??
+      (playbooks[0]
+        ? { name: "playbook", playbookId: playbooks[0].id }
+        : { name: "get-started" }),
+  );
+
+  const navigate: KitchenSinkNavigate = (next) => {
+    setRoute(next);
+  };
+
+  const mutatePlaybook = (
+    id: string,
+    updater: (playbook: PlaybookDetail) => PlaybookDetail,
+  ) => {
+    setPlaybooks((list) =>
+      list.map((playbook) =>
+        playbook.id === id ? updater(playbook) : playbook,
+      ),
+    );
+  };
+
+  const deletePlaybook = (id: string) => {
+    const remaining = playbooks.filter((playbook) => playbook.id !== id);
+    setPlaybooks(remaining);
+    if (remaining[0]) {
+      navigate({ name: "playbook", playbookId: remaining[0].id });
+    } else {
+      navigate({ name: "get-started" });
+    }
+  };
+
+  const createPlaybook = (values: { name: string; description?: string }) => {
+    const id = values.name.trim().toLowerCase().replace(/\s+/g, "-") || "new";
+    const created: PlaybookDetail = {
+      id,
+      name: values.name,
+      description: values.description ?? "",
+      userId: "kitchen-sink-user",
+      prompts: [],
+      servers: [],
+      paths: { streamable: `/${id}/mcp` },
+    };
+    setPlaybooks((list) => [...list, created]);
+    navigate({ name: "playbook", playbookId: id });
+  };
+
+  const sections: NavigationSection[] = [
+    {
+      id: "registries",
+      label: "Registries",
+      items: [
+        {
+          id: "mcp",
+          label: "MCP",
+          icon: <MCPIcon />,
+          isActive: route.name === "library" || route.name === "library-entry",
+          onClick: () => navigate({ name: "library" }),
+        },
+      ],
+    },
+    {
+      id: "playbooks",
+      label: "Playbooks",
+      isLoading: sidebarLoading,
+      items: playbooks.map((playbook) => ({
+        id: playbook.id,
+        label: playbook.name,
+        isActive:
+          (route.name === "playbook" && route.playbookId === playbook.id) ||
+          (route.name === "target" && route.playbookId === playbook.id),
+        onClick: () => navigate({ name: "playbook", playbookId: playbook.id }),
+      })),
+    },
+    {
+      id: "actions",
+      items: [
+        {
+          id: "new-playbook",
+          label: "New Playbook",
+          icon: <PlusIcon />,
+          isActive: route.name === "new-playbook",
+          onClick: () => navigate({ name: "new-playbook" }),
+        },
+        {
+          id: "documentation",
+          label: "Documentation",
+          icon: <BookOpenTextIcon weight="fill" />,
+          onClick: () =>
+            toast({
+              title: "Documentation",
+              description: "Would open https://docs.director.run",
+            }),
+        },
+        {
+          id: "github",
+          label: "Github",
+          icon: <GithubLogoIcon />,
+          onClick: () =>
+            toast({
+              title: "GitHub",
+              description: "Would open github.com/director-run/director",
+            }),
+        },
+        {
+          id: "settings",
+          label: "Settings",
+          icon: <GearIcon />,
+          isActive: route.name === "settings",
+          onClick: () => navigate({ name: "settings" }),
+        },
+      ],
+    },
+  ];
+
+  if (route.name === "get-started") {
+    return (
+      <>
+        <GetStartedRoute
+          navigate={navigate}
+          firstPlaybookId={playbooks[0]?.id}
+        />
+        <Toaster />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <LayoutRoot sections={sections}>
+        <LayoutView>{renderRoute()}</LayoutView>
+        <ChatToUs />
+      </LayoutRoot>
+      <Toaster />
+    </>
+  );
+
+  function renderRoute() {
+    switch (route.name) {
+      case "playbook": {
+        const playbook = playbooks.find((p) => p.id === route.playbookId);
+        if (!playbook) {
+          return <RouteNotFound label="playbook" />;
+        }
+        return (
+          <PlaybookDetailRoute
+            playbook={playbook}
+            tools={playbook.servers.length === 0 ? [] : tools}
+            connectionInfo={kitchenSinkConnectionInfo(playbook.id)}
+            navigate={navigate}
+            pageState={pageState}
+            onMutate={(updater) => mutatePlaybook(playbook.id, updater)}
+            onDelete={() => deletePlaybook(playbook.id)}
+          />
+        );
+      }
+      case "target": {
+        const playbook = playbooks.find((p) => p.id === route.playbookId);
+        const target = playbook?.servers.find(
+          (server) => server.name === route.targetId,
+        );
+        if (!playbook || !target) {
+          return <RouteNotFound label="server" />;
+        }
+        return (
+          <TargetDetailRoute
+            playbook={playbook}
+            target={target}
+            tools={tools}
+            navigate={navigate}
+            pageState={pageState}
+            onDelete={() => {
+              mutatePlaybook(playbook.id, (current) => ({
+                ...current,
+                servers: current.servers.filter(
+                  (server) => server.name !== target.name,
+                ),
+              }));
+              navigate({ name: "playbook", playbookId: playbook.id });
+            }}
+          />
+        );
+      }
+      case "library":
+        return (
+          <LibraryRoute
+            playbooks={playbooks}
+            navigate={navigate}
+            pageState={pageState}
+          />
+        );
+      case "library-entry":
+        return (
+          <LibraryEntryRoute
+            entryName={route.entryName}
+            playbooks={playbooks}
+            navigate={navigate}
+            pageState={pageState}
+          />
+        );
+      case "new-playbook":
+        return <PlaybookNewRoute onCreate={createPlaybook} />;
+      case "settings":
+        return <SettingsRoute pageState={pageState} />;
+      default:
+        return null;
+    }
+  }
+}
+
+function RouteNotFound({ label }: { label: string }) {
+  return (
+    <div className="grid grow place-items-center p-8">
+      <EmptyState>
+        <EmptyStateTitle>Not found</EmptyStateTitle>
+        <EmptyStateDescription>
+          The requested {label} does not exist.
+        </EmptyStateDescription>
+      </EmptyState>
+    </div>
+  );
+}

--- a/apps/studio/src/kitchen-sink/lib/routes/get-started-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/get-started-route.tsx
@@ -5,10 +5,8 @@ import { toast } from "@director.run/design/components/ui/toast.tsx";
 import { mockRegistryEntryList } from "@director.run/design/test/fixtures/registry/entry-list.ts";
 import { mockRegistryEntry } from "@director.run/design/test/fixtures/registry/entry.ts";
 import { useState } from "react";
-import { kitchenSinkConnectionInfo } from "../fixtures";
+import { delay, kitchenSinkConnectionInfo } from "../fixtures";
 import type { KitchenSinkNavigate } from "../types";
-
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const ONBOARDING_PLAYBOOK_ID = "getting-started";
 

--- a/apps/studio/src/kitchen-sink/lib/routes/get-started-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/get-started-route.tsx
@@ -1,0 +1,126 @@
+import { GetStartedCompleteDialog } from "@director.run/design/components/get-started/get-started-complete-dialog.tsx";
+import { GetStartedInstallServerDialog } from "@director.run/design/components/get-started/get-started-install-server-dialog.tsx";
+import { GetStartedPageView } from "@director.run/design/components/pages/get-started.tsx";
+import { toast } from "@director.run/design/components/ui/toast.tsx";
+import { mockRegistryEntryList } from "@director.run/design/test/fixtures/registry/entry-list.ts";
+import { mockRegistryEntry } from "@director.run/design/test/fixtures/registry/entry.ts";
+import { useState } from "react";
+import { kitchenSinkConnectionInfo } from "../fixtures";
+import type { KitchenSinkNavigate } from "../types";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const ONBOARDING_PLAYBOOK_ID = "getting-started";
+
+interface GetStartedRouteProps {
+  navigate: KitchenSinkNavigate;
+  firstPlaybookId?: string;
+}
+
+export function GetStartedRoute({
+  navigate,
+  firstPlaybookId,
+}: GetStartedRouteProps) {
+  const [currentPlaybook, setCurrentPlaybook] = useState<{
+    id: string;
+    servers: { name: string }[];
+  } | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [isPromptCompleted, setIsPromptCompleted] = useState(false);
+  const [installEntryName, setInstallEntryName] = useState<string | null>(null);
+  const [installOpen, setInstallOpen] = useState(false);
+  const [isInstalling, setIsInstalling] = useState(false);
+  const [completeOpen, setCompleteOpen] = useState(false);
+
+  const exitTo = firstPlaybookId
+    ? { name: "playbook" as const, playbookId: firstPlaybookId }
+    : { name: "library" as const };
+
+  const listEntry = mockRegistryEntryList.find(
+    (entry) => entry.name === installEntryName,
+  );
+  const installEntry = listEntry
+    ? {
+        ...mockRegistryEntry,
+        name: listEntry.name,
+        title: listEntry.title,
+        description: listEntry.description,
+        icon: listEntry.icon,
+        homepage: listEntry.homepage,
+      }
+    : mockRegistryEntry;
+
+  return (
+    <div className="h-screen w-screen overflow-y-auto bg-bg text-fg">
+      <GetStartedPageView
+        currentPlaybook={currentPlaybook}
+        isCreatePlaybookLoading={isCreating}
+        onCreatePlaybook={async () => {
+          setIsCreating(true);
+          await delay(500);
+          setCurrentPlaybook({ id: ONBOARDING_PLAYBOOK_ID, servers: [] });
+          setIsCreating(false);
+        }}
+        registryEntries={mockRegistryEntryList}
+        searchQuery={searchQuery}
+        onSearchQueryChange={setSearchQuery}
+        onClickRegistryEntry={(entry) => {
+          setInstallEntryName(entry.name);
+          setInstallOpen(true);
+        }}
+        connectionInfo={kitchenSinkConnectionInfo(
+          currentPlaybook?.id ?? ONBOARDING_PLAYBOOK_ID,
+        )}
+        isConnectionInfoLoading={false}
+        onDone={() => setCompleteOpen(true)}
+        isPromptCompleted={isPromptCompleted}
+        onSkipPrompt={() => setIsPromptCompleted(true)}
+        onPromptFormSubmit={async () => {
+          await delay(400);
+          setIsPromptCompleted(true);
+          toast({
+            title: "Prompt saved",
+            description: "Your prompt was saved.",
+          });
+        }}
+        isPromptSubmitting={false}
+      />
+
+      <GetStartedInstallServerDialog
+        registryEntry={installEntry}
+        playbooks={[]}
+        open={installOpen}
+        onOpenChange={setInstallOpen}
+        isInstalling={isInstalling}
+        onClickInstall={async () => {
+          setIsInstalling(true);
+          await delay(600);
+          setCurrentPlaybook((current) =>
+            current
+              ? {
+                  ...current,
+                  servers: [
+                    ...current.servers,
+                    { name: installEntryName ?? "server" },
+                  ],
+                }
+              : current,
+          );
+          setIsInstalling(false);
+          setInstallOpen(false);
+          toast({
+            title: "Server added",
+            description: "The server has been added to your playbook.",
+          });
+        }}
+      />
+
+      <GetStartedCompleteDialog
+        open={completeOpen}
+        onClickLibrary={() => navigate({ name: "library" })}
+        onClickPlaybook={() => navigate(exitTo)}
+      />
+    </div>
+  );
+}

--- a/apps/studio/src/kitchen-sink/lib/routes/library-entry-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/library-entry-route.tsx
@@ -27,9 +27,8 @@ import { toast } from "@director.run/design/components/ui/toast.tsx";
 import { mockRegistryEntryList } from "@director.run/design/test/fixtures/registry/entry-list.ts";
 import { mockRegistryEntry } from "@director.run/design/test/fixtures/registry/entry.ts";
 import { useState } from "react";
+import { delay } from "../fixtures";
 import type { KitchenSinkNavigate, KitchenSinkPageState } from "../types";
-
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 interface LibraryEntryRouteProps {
   entryName: string;

--- a/apps/studio/src/kitchen-sink/lib/routes/library-entry-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/library-entry-route.tsx
@@ -1,0 +1,132 @@
+import { LayoutBreadcrumbHeader } from "@director.run/design/components/layout/layout-breadcrumb-header.tsx";
+import {
+  LayoutView,
+  LayoutViewContent,
+} from "@director.run/design/components/layout/layout.tsx";
+import { RegistryDetailSidebar } from "@director.run/design/components/registry-detail-sidebar.tsx";
+import { RegistryItem } from "@director.run/design/components/registry-item.tsx";
+import { RegistryEntrySkeleton } from "@director.run/design/components/registry/registry-entry-skeleton.tsx";
+import { RegistryInstallForm } from "@director.run/design/components/registry/registry-install-form.tsx";
+import {
+  SplitView,
+  SplitViewMain,
+  SplitViewSide,
+} from "@director.run/design/components/split-view.tsx";
+import type {
+  PlaybookDetail,
+  RegistryEntryDetail,
+} from "@director.run/design/components/types.ts";
+import { Button } from "@director.run/design/components/ui/button.tsx";
+import { Container } from "@director.run/design/components/ui/container.tsx";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@director.run/design/components/ui/popover.tsx";
+import { toast } from "@director.run/design/components/ui/toast.tsx";
+import { mockRegistryEntryList } from "@director.run/design/test/fixtures/registry/entry-list.ts";
+import { mockRegistryEntry } from "@director.run/design/test/fixtures/registry/entry.ts";
+import { useState } from "react";
+import type { KitchenSinkNavigate, KitchenSinkPageState } from "../types";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+interface LibraryEntryRouteProps {
+  entryName: string;
+  playbooks: PlaybookDetail[];
+  navigate: KitchenSinkNavigate;
+  pageState: KitchenSinkPageState;
+}
+
+export function LibraryEntryRoute({
+  entryName,
+  playbooks,
+  navigate,
+  pageState,
+}: LibraryEntryRouteProps) {
+  const [installFormOpen, setInstallFormOpen] = useState(false);
+  const [isInstalling, setIsInstalling] = useState(false);
+
+  if (pageState === "loading") {
+    return <RegistryEntrySkeleton />;
+  }
+
+  const listEntry = mockRegistryEntryList.find(
+    (entry) => entry.name === entryName,
+  );
+  const entry: RegistryEntryDetail = listEntry
+    ? {
+        ...mockRegistryEntry,
+        name: listEntry.name,
+        title: listEntry.title,
+        description: listEntry.description,
+        icon: listEntry.icon,
+        homepage: listEntry.homepage,
+      }
+    : mockRegistryEntry;
+
+  const handleInstall = async (values: {
+    playbookId?: string;
+    parameters?: Record<string, string>;
+  }) => {
+    setIsInstalling(true);
+    await delay(600);
+    setIsInstalling(false);
+    setInstallFormOpen(false);
+    toast({
+      title: "Playbook installed",
+      description: `${entry.title} was added to your playbook.`,
+    });
+    if (values.playbookId) {
+      navigate({ name: "playbook", playbookId: values.playbookId });
+    }
+  };
+
+  return (
+    <LayoutView>
+      <LayoutBreadcrumbHeader
+        breadcrumbs={[
+          { title: "Library", onClick: () => navigate({ name: "library" }) },
+          { title: entry.title },
+        ]}
+      >
+        <Popover open={installFormOpen} onOpenChange={setInstallFormOpen}>
+          <PopoverTrigger asChild>
+            <Button className="ml-auto lg:hidden">Add to playbook</Button>
+          </PopoverTrigger>
+          <PopoverContent
+            side="bottom"
+            align="end"
+            sideOffset={8}
+            className="w-sm max-w-[80dvw] rounded-[20px] lg:hidden"
+          >
+            <RegistryInstallForm
+              registryEntry={entry}
+              playbooks={playbooks}
+              onSubmit={handleInstall}
+              isSubmitting={isInstalling}
+            />
+          </PopoverContent>
+        </Popover>
+      </LayoutBreadcrumbHeader>
+
+      <LayoutViewContent>
+        <Container size="xl">
+          <SplitView>
+            <SplitViewMain>
+              <RegistryItem entry={entry} />
+            </SplitViewMain>
+            <SplitViewSide>
+              <RegistryDetailSidebar
+                entry={entry}
+                playbooks={playbooks}
+                onClickInstall={handleInstall}
+                isInstalling={isInstalling}
+              />
+            </SplitViewSide>
+          </SplitView>
+        </Container>
+      </LayoutViewContent>
+    </LayoutView>
+  );
+}

--- a/apps/studio/src/kitchen-sink/lib/routes/library-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/library-route.tsx
@@ -1,0 +1,134 @@
+import { LayoutBreadcrumbHeader } from "@director.run/design/components/layout/layout-breadcrumb-header.tsx";
+import {
+  LayoutView,
+  LayoutViewContent,
+} from "@director.run/design/components/layout/layout.tsx";
+import { PlaybookTargetAddSheet } from "@director.run/design/components/mcp-servers/mcp-add-sheet.tsx";
+import { RegistryItemList } from "@director.run/design/components/pages/registry-item-list.tsx";
+import { RegistryLibrarySkeleton } from "@director.run/design/components/registry/registry-library-skeleton.tsx";
+import type { PlaybookDetail } from "@director.run/design/components/types.ts";
+import {
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateTitle,
+} from "@director.run/design/components/ui/empty-state.tsx";
+import { toast } from "@director.run/design/components/ui/toast.tsx";
+import { mockRegistryEntryList } from "@director.run/design/test/fixtures/registry/entry-list.ts";
+import { useState } from "react";
+import type { KitchenSinkNavigate, KitchenSinkPageState } from "../types";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const PAGE_SIZE = 6;
+
+interface LibraryRouteProps {
+  playbooks: PlaybookDetail[];
+  navigate: KitchenSinkNavigate;
+  pageState: KitchenSinkPageState;
+  initialSearchQuery?: string;
+}
+
+export function LibraryRoute({
+  playbooks,
+  navigate,
+  pageState,
+  initialSearchQuery = "",
+}: LibraryRouteProps) {
+  const [pageIndex, setPageIndex] = useState(0);
+  const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
+  const [addSheetOpen, setAddSheetOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (pageState === "loading") {
+    return <RegistryLibrarySkeleton />;
+  }
+
+  if (pageState === "error") {
+    return (
+      <LayoutView>
+        <LayoutViewContent>
+          <div className="inset-0 grid place-items-center">
+            <EmptyState>
+              <EmptyStateTitle>Something went wrong.</EmptyStateTitle>
+              <EmptyStateDescription>Please try again</EmptyStateDescription>
+            </EmptyState>
+          </div>
+        </LayoutViewContent>
+      </LayoutView>
+    );
+  }
+
+  const query = searchQuery.trim().toLowerCase();
+  const filtered = query
+    ? mockRegistryEntryList.filter((entry) =>
+        `${entry.title} ${entry.name} ${entry.description}`
+          .toLowerCase()
+          .includes(query),
+      )
+    : mockRegistryEntryList;
+
+  const totalItems = filtered.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / PAGE_SIZE));
+  const safePageIndex = Math.min(pageIndex, totalPages - 1);
+  const pageEntries = filtered.slice(
+    safePageIndex * PAGE_SIZE,
+    safePageIndex * PAGE_SIZE + PAGE_SIZE,
+  );
+
+  return (
+    <LayoutView>
+      <LayoutBreadcrumbHeader breadcrumbs={[{ title: "Library" }]} />
+
+      <LayoutViewContent>
+        <RegistryItemList
+          entries={pageEntries}
+          pagination={{
+            pageIndex: safePageIndex,
+            totalPages,
+            totalItems,
+            hasPreviousPage: safePageIndex > 0,
+            hasNextPage: safePageIndex < totalPages - 1,
+          }}
+          searchQuery={searchQuery}
+          onSearchQueryChange={(value) => {
+            setSearchQuery(value);
+            setPageIndex(0);
+          }}
+          onPageChange={setPageIndex}
+          onManualAddClick={() => setAddSheetOpen(true)}
+          onEntryClick={(entryName) =>
+            navigate({ name: "library-entry", entryName })
+          }
+        />
+
+        <PlaybookTargetAddSheet
+          open={addSheetOpen}
+          onOpenChange={setAddSheetOpen}
+          playbooks={playbooks.map((playbook) => ({
+            id: playbook.id,
+            name: playbook.name,
+          }))}
+          isSubmitting={isSubmitting}
+          onSubmit={async (data) => {
+            if (!data.playbookId) {
+              toast({
+                title: "No playbook selected",
+                description: "Please select a playbook before adding a server.",
+              });
+              return;
+            }
+            setIsSubmitting(true);
+            await delay(600);
+            setIsSubmitting(false);
+            setAddSheetOpen(false);
+            toast({
+              title: "Server added",
+              description: "The server has been added to the playbook.",
+            });
+            navigate({ name: "playbook", playbookId: data.playbookId });
+          }}
+        />
+      </LayoutViewContent>
+    </LayoutView>
+  );
+}

--- a/apps/studio/src/kitchen-sink/lib/routes/library-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/library-route.tsx
@@ -15,9 +15,8 @@ import {
 import { toast } from "@director.run/design/components/ui/toast.tsx";
 import { mockRegistryEntryList } from "@director.run/design/test/fixtures/registry/entry-list.ts";
 import { useState } from "react";
+import { delay } from "../fixtures";
 import type { KitchenSinkNavigate, KitchenSinkPageState } from "../types";
-
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const PAGE_SIZE = 6;
 

--- a/apps/studio/src/kitchen-sink/lib/routes/playbook-detail-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/playbook-detail-route.tsx
@@ -1,0 +1,272 @@
+import { LayoutBreadcrumbHeader } from "@director.run/design/components/layout/layout-breadcrumb-header.tsx";
+import { LayoutViewContent } from "@director.run/design/components/layout/layout.tsx";
+import { FullScreenError } from "@director.run/design/components/pages/global/error.tsx";
+import type { ConnectionInfo } from "@director.run/design/components/playbooks-clients/playbook-section-connect.tsx";
+import { PlaybookSectionConnect } from "@director.run/design/components/playbooks-clients/playbook-section-connect.tsx";
+import { PlaybookActionsDropdown } from "@director.run/design/components/playbooks/playbook-actions-dropdown.tsx";
+import type { PlaybookFormData } from "@director.run/design/components/playbooks/playbook-form.tsx";
+import { PlaybookSettingsSheet } from "@director.run/design/components/playbooks/playbook-settings-sheet.tsx";
+import { PlaybookSkeleton } from "@director.run/design/components/playbooks/playbook-skeleton.tsx";
+import { PromptList } from "@director.run/design/components/prompts/prompt-list.tsx";
+import { PlaybookServerList } from "@director.run/design/components/servers/server-list.tsx";
+import {
+  SplitView,
+  SplitViewMain,
+  SplitViewSide,
+} from "@director.run/design/components/split-view.tsx";
+import { ToolList } from "@director.run/design/components/tools/tool-list.tsx";
+import type {
+  MCPTool,
+  PlaybookDetail,
+} from "@director.run/design/components/types.ts";
+import { ConfirmDialog } from "@director.run/design/components/ui/confirm-dialog.tsx";
+import { Container } from "@director.run/design/components/ui/container.tsx";
+import {
+  Section,
+  SectionDescription,
+  SectionHeader,
+  SectionTitle,
+} from "@director.run/design/components/ui/section.tsx";
+import { Tab, Tabs } from "@director.run/design/components/ui/tabs.tsx";
+import { toast } from "@director.run/design/components/ui/toast.tsx";
+import { DesktopIcon, NotebookIcon, ToolboxIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import type { KitchenSinkNavigate, KitchenSinkPageState } from "../types";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const slugify = (value: string) =>
+  value.trim().toLowerCase().replace(/\s+/g, "-") || "prompt";
+
+interface PlaybookDetailRouteProps {
+  playbook: PlaybookDetail;
+  tools: MCPTool[];
+  connectionInfo: ConnectionInfo;
+  navigate: KitchenSinkNavigate;
+  pageState: KitchenSinkPageState;
+  onMutate: (updater: (playbook: PlaybookDetail) => PlaybookDetail) => void;
+  onDelete: () => void;
+}
+
+export function PlaybookDetailRoute({
+  playbook,
+  tools,
+  connectionInfo,
+  navigate,
+  pageState,
+  onMutate,
+  onDelete,
+}: PlaybookDetailRouteProps) {
+  if (pageState === "loading") {
+    return <PlaybookSkeleton />;
+  }
+
+  if (pageState === "error") {
+    return (
+      <FullScreenError
+        icon="dead-smiley"
+        fullScreen={true}
+        title="Unexpected Error"
+        subtitle="Something went wrong loading this playbook."
+      />
+    );
+  }
+
+  return (
+    <>
+      <LayoutBreadcrumbHeader breadcrumbs={[{ title: playbook.name }]}>
+        <PlaybookEditMenu
+          playbook={playbook}
+          onMutate={onMutate}
+          onDelete={onDelete}
+        />
+      </LayoutBreadcrumbHeader>
+
+      <LayoutViewContent>
+        <Container size="xl">
+          <SplitView>
+            <SplitViewMain>
+              <Section className="gap-y-8">
+                <SectionHeader>
+                  <SectionTitle>{playbook.name}</SectionTitle>
+                  <SectionDescription>
+                    {playbook.description}
+                  </SectionDescription>
+                </SectionHeader>
+
+                <Tabs default="servers">
+                  <Tab
+                    id="servers"
+                    label="Servers"
+                    icon={<DesktopIcon />}
+                    content={
+                      <PlaybookServerList
+                        servers={playbook.servers}
+                        onClickServer={(server) =>
+                          navigate({
+                            name: "target",
+                            playbookId: playbook.id,
+                            targetId: server.name,
+                          })
+                        }
+                        onClickAddServer={() => navigate({ name: "library" })}
+                        onClickAuthorize={async (server) => {
+                          await delay(400);
+                          toast({
+                            title: "Authenticating",
+                            description: `Would start OAuth for ${server.name}.`,
+                          });
+                        }}
+                      />
+                    }
+                  />
+                  <Tab
+                    id="tools"
+                    label="Tools"
+                    icon={<ToolboxIcon />}
+                    content={
+                      <ToolList
+                        tools={tools}
+                        toolsLoading={false}
+                        editable={true}
+                        onUpdateTools={async () => {
+                          await delay(600);
+                          toast({
+                            title: "Tools updated",
+                            description: "Your tools have been updated.",
+                          });
+                        }}
+                      />
+                    }
+                  />
+                  <Tab
+                    id="prompts"
+                    label="Prompts"
+                    icon={<NotebookIcon />}
+                    content={
+                      <PromptList
+                        prompts={playbook.prompts ?? []}
+                        onCreatePrompt={async (values) => {
+                          await delay(400);
+                          onMutate((current) => ({
+                            ...current,
+                            prompts: [
+                              ...(current.prompts ?? []),
+                              {
+                                name: slugify(values.title),
+                                title: values.title,
+                                description: values.description,
+                                body: values.body,
+                              },
+                            ],
+                          }));
+                          toast({
+                            title: "Prompt saved",
+                            description: "Your prompt was saved.",
+                          });
+                        }}
+                        onEditPrompt={async (promptName, values) => {
+                          await delay(400);
+                          onMutate((current) => ({
+                            ...current,
+                            prompts: (current.prompts ?? []).map((prompt) =>
+                              prompt.name === promptName
+                                ? { ...prompt, ...values }
+                                : prompt,
+                            ),
+                          }));
+                          toast({
+                            title: "Prompt updated",
+                            description: "Your prompt was updated.",
+                          });
+                        }}
+                        onDeletePrompt={async (promptName) => {
+                          await delay(400);
+                          onMutate((current) => ({
+                            ...current,
+                            prompts: (current.prompts ?? []).filter(
+                              (prompt) => prompt.name !== promptName,
+                            ),
+                          }));
+                          toast({
+                            title: "Prompt deleted",
+                            description: "Your prompt was deleted.",
+                          });
+                        }}
+                      />
+                    }
+                  />
+                </Tabs>
+              </Section>
+            </SplitViewMain>
+            <SplitViewSide>
+              <PlaybookSectionConnect
+                connectionInfo={connectionInfo}
+                isLoading={false}
+              />
+            </SplitViewSide>
+          </SplitView>
+        </Container>
+      </LayoutViewContent>
+    </>
+  );
+}
+
+function PlaybookEditMenu({
+  playbook,
+  onMutate,
+  onDelete,
+}: {
+  playbook: PlaybookDetail;
+  onMutate: (updater: (playbook: PlaybookDetail) => PlaybookDetail) => void;
+  onDelete: () => void;
+}) {
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const handleUpdate = async (values: PlaybookFormData) => {
+    await delay(400);
+    onMutate((current) => ({
+      ...current,
+      name: values.name,
+      description: values.description ?? "",
+    }));
+    toast({
+      title: "Playbook updated",
+      description: "This playbook was successfully updated.",
+    });
+    setSettingsOpen(false);
+  };
+
+  const handleDelete = async () => {
+    await delay(400);
+    toast({
+      title: "Playbook deleted",
+      description: "This playbook was successfully deleted.",
+    });
+    setDeleteOpen(false);
+    onDelete();
+  };
+
+  return (
+    <>
+      <PlaybookActionsDropdown
+        onSettingsClick={() => setSettingsOpen(true)}
+        onDeleteClick={() => setDeleteOpen(true)}
+      />
+      <PlaybookSettingsSheet
+        playbook={playbook}
+        onSubmit={handleUpdate}
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+      />
+      <ConfirmDialog
+        title="Delete playbook?"
+        description="Are you sure you want to delete this playbook? This action cannot be undone."
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        onConfirm={handleDelete}
+      />
+    </>
+  );
+}

--- a/apps/studio/src/kitchen-sink/lib/routes/playbook-detail-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/playbook-detail-route.tsx
@@ -31,12 +31,15 @@ import { Tab, Tabs } from "@director.run/design/components/ui/tabs.tsx";
 import { toast } from "@director.run/design/components/ui/toast.tsx";
 import { DesktopIcon, NotebookIcon, ToolboxIcon } from "@phosphor-icons/react";
 import { useState } from "react";
+import { delay } from "../fixtures";
 import type { KitchenSinkNavigate, KitchenSinkPageState } from "../types";
 
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
 const slugify = (value: string) =>
-  value.trim().toLowerCase().replace(/\s+/g, "-") || "prompt";
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "prompt";
 
 interface PlaybookDetailRouteProps {
   playbook: PlaybookDetail;

--- a/apps/studio/src/kitchen-sink/lib/routes/playbook-new-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/playbook-new-route.tsx
@@ -1,0 +1,36 @@
+import { LayoutBreadcrumbHeader } from "@director.run/design/components/layout/layout-breadcrumb-header.tsx";
+import { LayoutViewContent } from "@director.run/design/components/layout/layout.tsx";
+import { PlaybookCreate } from "@director.run/design/components/pages/playbook-new.tsx";
+import type { PlaybookFormData } from "@director.run/design/components/playbooks/playbook-form.tsx";
+import { toast } from "@director.run/design/components/ui/toast.tsx";
+import { useState } from "react";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+interface PlaybookNewRouteProps {
+  onCreate: (values: { name: string; description?: string }) => void;
+}
+
+export function PlaybookNewRoute({ onCreate }: PlaybookNewRouteProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (values: PlaybookFormData) => {
+    setIsSubmitting(true);
+    await delay(500);
+    setIsSubmitting(false);
+    toast({
+      title: "Playbook created",
+      description: "This playbook was successfully created.",
+    });
+    onCreate(values);
+  };
+
+  return (
+    <>
+      <LayoutBreadcrumbHeader breadcrumbs={[{ title: "New Playbooks" }]} />
+      <LayoutViewContent>
+        <PlaybookCreate onSubmit={handleSubmit} isSubmitting={isSubmitting} />
+      </LayoutViewContent>
+    </>
+  );
+}

--- a/apps/studio/src/kitchen-sink/lib/routes/playbook-new-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/playbook-new-route.tsx
@@ -4,8 +4,7 @@ import { PlaybookCreate } from "@director.run/design/components/pages/playbook-n
 import type { PlaybookFormData } from "@director.run/design/components/playbooks/playbook-form.tsx";
 import { toast } from "@director.run/design/components/ui/toast.tsx";
 import { useState } from "react";
-
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+import { delay } from "../fixtures";
 
 interface PlaybookNewRouteProps {
   onCreate: (values: { name: string; description?: string }) => void;

--- a/apps/studio/src/kitchen-sink/lib/routes/settings-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/settings-route.tsx
@@ -1,0 +1,62 @@
+import { LayoutBreadcrumbHeader } from "@director.run/design/components/layout/layout-breadcrumb-header.tsx";
+import { LayoutViewContent } from "@director.run/design/components/layout/layout.tsx";
+import { SettingsPage } from "@director.run/design/components/pages/settings.tsx";
+import { toast } from "@director.run/design/components/ui/toast.tsx";
+import { useState } from "react";
+import { kitchenSinkApiKey } from "../fixtures";
+import type { KitchenSinkPageState } from "../types";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const GENERATED_API_KEY = "dk_live_9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c";
+
+interface SettingsRouteProps {
+  pageState: KitchenSinkPageState;
+}
+
+export function SettingsRoute({ pageState }: SettingsRouteProps) {
+  const [apiKey, setApiKey] = useState<typeof kitchenSinkApiKey | null>(
+    kitchenSinkApiKey,
+  );
+  const [newApiKey, setNewApiKey] = useState<string | null>(null);
+  const [isRecycling, setIsRecycling] = useState(false);
+
+  const regenerate = async () => {
+    setIsRecycling(true);
+    await delay(600);
+    setApiKey(kitchenSinkApiKey);
+    setNewApiKey(GENERATED_API_KEY);
+    setIsRecycling(false);
+  };
+
+  return (
+    <>
+      <LayoutBreadcrumbHeader breadcrumbs={[{ title: "Settings" }]} />
+      <LayoutViewContent>
+        <SettingsPage
+          settings={{ Email: "user@director.run" }}
+          apiKey={apiKey}
+          newApiKey={newApiKey}
+          isLoadingApiKey={pageState === "loading"}
+          isRecyclingApiKey={isRecycling}
+          onCreateApiKey={regenerate}
+          onRecycleApiKey={regenerate}
+          onClearNewApiKey={() => setNewApiKey(null)}
+          onCopyApiKey={(text) => {
+            void navigator.clipboard?.writeText(text);
+            toast({
+              title: "Copied",
+              description: "The API key was copied to your clipboard.",
+            });
+          }}
+          onClickLogout={() => {
+            toast({
+              title: "Signed out",
+              description: "You would be returned to the login screen.",
+            });
+          }}
+        />
+      </LayoutViewContent>
+    </>
+  );
+}

--- a/apps/studio/src/kitchen-sink/lib/routes/settings-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/settings-route.tsx
@@ -3,10 +3,8 @@ import { LayoutViewContent } from "@director.run/design/components/layout/layout
 import { SettingsPage } from "@director.run/design/components/pages/settings.tsx";
 import { toast } from "@director.run/design/components/ui/toast.tsx";
 import { useState } from "react";
-import { kitchenSinkApiKey } from "../fixtures";
+import { delay, kitchenSinkApiKey } from "../fixtures";
 import type { KitchenSinkPageState } from "../types";
-
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const GENERATED_API_KEY = "dk_live_9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c";
 
@@ -43,7 +41,10 @@ export function SettingsRoute({ pageState }: SettingsRouteProps) {
           onRecycleApiKey={regenerate}
           onClearNewApiKey={() => setNewApiKey(null)}
           onCopyApiKey={(text) => {
-            void navigator.clipboard?.writeText(text);
+            if (!navigator.clipboard) {
+              return;
+            }
+            void navigator.clipboard.writeText(text);
             toast({
               title: "Copied",
               description: "The API key was copied to your clipboard.",

--- a/apps/studio/src/kitchen-sink/lib/routes/target-detail-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/target-detail-route.tsx
@@ -47,9 +47,8 @@ import {
   TrashIcon,
 } from "@phosphor-icons/react";
 import { useState } from "react";
+import { delay } from "../fixtures";
 import type { KitchenSinkNavigate, KitchenSinkPageState } from "../types";
-
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 interface TargetDetailRouteProps {
   playbook: PlaybookDetail;

--- a/apps/studio/src/kitchen-sink/lib/routes/target-detail-route.tsx
+++ b/apps/studio/src/kitchen-sink/lib/routes/target-detail-route.tsx
@@ -1,0 +1,261 @@
+import { LayoutBreadcrumbHeader } from "@director.run/design/components/layout/layout-breadcrumb-header.tsx";
+import {
+  LayoutView,
+  LayoutViewContent,
+} from "@director.run/design/components/layout/layout.tsx";
+import { McpLogo } from "@director.run/design/components/mcp-logo.tsx";
+import { PlaybookTargetPropertyList } from "@director.run/design/components/mcp-servers/playbook-target-property-list.tsx";
+import { FullScreenError } from "@director.run/design/components/pages/global/error.tsx";
+import { PlaybookSkeleton } from "@director.run/design/components/playbooks/playbook-skeleton.tsx";
+import { RegistryEntryReadme } from "@director.run/design/components/registry/registry-entry-readme.tsx";
+import { ToolList } from "@director.run/design/components/tools/tool-list.tsx";
+import type {
+  MCPTool,
+  PlaybookDetail,
+  PlaybookTarget,
+} from "@director.run/design/components/types.ts";
+import { Button } from "@director.run/design/components/ui/button.tsx";
+import { ConfirmDialog } from "@director.run/design/components/ui/confirm-dialog.tsx";
+import { Container } from "@director.run/design/components/ui/container.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@director.run/design/components/ui/dropdown-menu.tsx";
+import { Markdown } from "@director.run/design/components/ui/markdown.tsx";
+import {
+  MenuItemIcon,
+  MenuItemLabel,
+} from "@director.run/design/components/ui/menu.tsx";
+import {
+  Section,
+  SectionDescription,
+  SectionHeader,
+  SectionTitle,
+} from "@director.run/design/components/ui/section.tsx";
+import { Tab, Tabs } from "@director.run/design/components/ui/tabs.tsx";
+import { toast } from "@director.run/design/components/ui/toast.tsx";
+import { mockRegistryEntry } from "@director.run/design/test/fixtures/registry/entry.ts";
+import {
+  BookOpenTextIcon,
+  DotsThreeOutlineVerticalIcon,
+  HardDriveIcon,
+  SignOutIcon,
+  ToolboxIcon,
+  TrashIcon,
+} from "@phosphor-icons/react";
+import { useState } from "react";
+import type { KitchenSinkNavigate, KitchenSinkPageState } from "../types";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+interface TargetDetailRouteProps {
+  playbook: PlaybookDetail;
+  target: PlaybookTarget;
+  tools: MCPTool[];
+  navigate: KitchenSinkNavigate;
+  pageState: KitchenSinkPageState;
+  onDelete: () => void;
+}
+
+export function TargetDetailRoute({
+  playbook,
+  target,
+  tools,
+  navigate,
+  pageState,
+  onDelete,
+}: TargetDetailRouteProps) {
+  if (pageState === "loading") {
+    return <PlaybookSkeleton />;
+  }
+
+  if (pageState === "error") {
+    return (
+      <FullScreenError
+        icon="dead-smiley"
+        fullScreen={true}
+        title="Unexpected Error"
+        subtitle="Something went wrong loading this server."
+      />
+    );
+  }
+
+  return (
+    <LayoutView>
+      <LayoutBreadcrumbHeader
+        breadcrumbs={[
+          {
+            title: playbook.name,
+            onClick: () =>
+              navigate({ name: "playbook", playbookId: playbook.id }),
+          },
+          { title: target.name },
+        ]}
+      >
+        <TargetActionsDropdown
+          target={target}
+          onDelete={onDelete}
+          playbookName={playbook.name}
+        />
+      </LayoutBreadcrumbHeader>
+
+      <LayoutViewContent>
+        <Container size="lg">
+          <Section className="gap-y-8">
+            <McpLogo src={mockRegistryEntry.icon} className="size-9" />
+            <SectionHeader>
+              <SectionTitle>{target.name}</SectionTitle>
+              <SectionDescription>
+                Installed on{" "}
+                <button
+                  type="button"
+                  onClick={() =>
+                    navigate({ name: "playbook", playbookId: playbook.id })
+                  }
+                  className="cursor-pointer text-fg underline"
+                >
+                  {playbook.name}
+                </button>
+              </SectionDescription>
+            </SectionHeader>
+
+            <Markdown>{mockRegistryEntry.description}</Markdown>
+          </Section>
+
+          <Tabs default="tools">
+            <Tab
+              id="readme"
+              label="Readme"
+              icon={<BookOpenTextIcon />}
+              content={
+                <RegistryEntryReadme readme={mockRegistryEntry.readme} />
+              }
+            />
+            <Tab
+              id="tools"
+              label="Tools"
+              icon={<ToolboxIcon />}
+              content={<ToolList tools={tools} toolsLoading={false} />}
+            />
+            <Tab
+              id="properties"
+              label="Properties"
+              icon={<HardDriveIcon />}
+              content={
+                <Section>
+                  <SectionHeader>
+                    <SectionTitle variant="h2" asChild>
+                      <h3>Transport Configuration</h3>
+                    </SectionTitle>
+                  </SectionHeader>
+                  <PlaybookTargetPropertyList target={target} />
+                </Section>
+              }
+            />
+          </Tabs>
+        </Container>
+      </LayoutViewContent>
+    </LayoutView>
+  );
+}
+
+function TargetActionsDropdown({
+  target,
+  onDelete,
+  playbookName,
+}: {
+  target: PlaybookTarget;
+  onDelete: () => void;
+  playbookName: string;
+}) {
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [logoutOpen, setLogoutOpen] = useState(false);
+
+  const isHttp = target.type === "http";
+  const isAuthenticated =
+    target.type === "http" && Boolean(target.connectionInfo?.isAuthenticated);
+
+  const handleDelete = async () => {
+    await delay(400);
+    toast({
+      title: "Server deleted",
+      description: `${target.name} was removed from ${playbookName}.`,
+    });
+    setDeleteOpen(false);
+    onDelete();
+  };
+
+  const handleLogout = async () => {
+    await delay(400);
+    toast({
+      title: "Logged out",
+      description: `${target.name} was logged out.`,
+    });
+    setLogoutOpen(false);
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="radix-state-[open]:bg-accent-subtle"
+          >
+            <DotsThreeOutlineVerticalIcon weight="fill" className="!size-4" />
+            <span className="sr-only">Server actions</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuGroup>
+            {isHttp && isAuthenticated && (
+              <DropdownMenuItem onSelect={() => setLogoutOpen(true)}>
+                <MenuItemIcon>
+                  <SignOutIcon />
+                </MenuItemIcon>
+                <MenuItemLabel>Logout</MenuItemLabel>
+              </DropdownMenuItem>
+            )}
+            {isHttp && !isAuthenticated && (
+              <DropdownMenuItem
+                onSelect={async () => {
+                  await delay(400);
+                  toast({
+                    title: "Authenticating",
+                    description: `Would start OAuth for ${target.name}.`,
+                  });
+                }}
+              >
+                <MenuItemLabel>Authenticate</MenuItemLabel>
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem onSelect={() => setDeleteOpen(true)}>
+              <MenuItemIcon>
+                <TrashIcon />
+              </MenuItemIcon>
+              <MenuItemLabel>Delete</MenuItemLabel>
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <ConfirmDialog
+        title="Delete this server"
+        description="Are you sure you want to delete this server? This action cannot be undone."
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        onConfirm={handleDelete}
+      />
+      <ConfirmDialog
+        title="Logout this server"
+        description="Are you sure you want to logout this server? This action cannot be undone."
+        open={logoutOpen}
+        onOpenChange={setLogoutOpen}
+        onConfirm={handleLogout}
+      />
+    </>
+  );
+}

--- a/apps/studio/src/kitchen-sink/lib/types.ts
+++ b/apps/studio/src/kitchen-sink/lib/types.ts
@@ -1,0 +1,31 @@
+import type { PlaybookDetail } from "@director.run/design/components/types.ts";
+
+/**
+ * In-memory route model for the kitchen-sink mock app. Mirrors the real
+ * react-router routes in `apps/studio/src/main.tsx` but drives navigation
+ * from local state instead of the URL.
+ */
+export type KitchenSinkRoute =
+  | { name: "playbook"; playbookId: string }
+  | { name: "target"; playbookId: string; targetId: string }
+  | { name: "library" }
+  | { name: "library-entry"; entryName: string }
+  | { name: "new-playbook" }
+  | { name: "settings" }
+  | { name: "get-started" };
+
+/** Forces a route to render its populated, loading, or error variant. */
+export type KitchenSinkPageState = "default" | "loading" | "error";
+
+export interface KitchenSinkAppProps {
+  /** Route to render first. Defaults to the first playbook's detail view. */
+  initialRoute?: KitchenSinkRoute;
+  /** Playbooks shown in the sidebar and detail views. */
+  initialPlaybooks?: PlaybookDetail[];
+  /** Renders the sidebar playbook section in its loading (scramble) state. */
+  sidebarLoading?: boolean;
+  /** Forces every route into a shared populated/loading/error state. */
+  pageState?: KitchenSinkPageState;
+}
+
+export type KitchenSinkNavigate = (route: KitchenSinkRoute) => void;

--- a/apps/studio/src/kitchen-sink/pages-connect.stories.tsx
+++ b/apps/studio/src/kitchen-sink/pages-connect.stories.tsx
@@ -1,0 +1,51 @@
+import { ConnectPage } from "@director.run/design/components/pages/auth/connect.tsx";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const scopes = ["mcp:tools", "mcp:prompts", "openid", "profile"];
+const redirectUri = "https://claude.ai/api/mcp/auth_callback";
+
+/**
+ * The OAuth connect/consent page. Only its sub-components have stories today;
+ * these cover the full page across the login, consent, loading and error
+ * states.
+ */
+const meta = {
+  title: "kitchen-sink/pages/connect",
+  component: ConnectPage,
+  parameters: { layout: "fullscreen" },
+  args: {
+    error: null,
+    isLoading: false,
+    isAuthenticated: false,
+    clientName: "Claude Desktop",
+    scopes: [],
+    redirectUri: null,
+    onApprove: () => {},
+    onDeny: () => {},
+    defaultValues: { email: "", password: "" },
+    onLogin: async () => {},
+    signupLink: <a href="/signup">Sign up</a>,
+  },
+} satisfies Meta<typeof ConnectPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const LoggedOut: Story = {};
+
+export const Consent: Story = {
+  args: { isAuthenticated: true, scopes, redirectUri },
+};
+
+export const Loading: Story = {
+  args: { isAuthenticated: true, isLoading: true, scopes, redirectUri },
+};
+
+export const Error: Story = {
+  args: {
+    isAuthenticated: true,
+    scopes,
+    redirectUri,
+    error: { message: "Authorization failed. Please try again." } as Error,
+  },
+};

--- a/apps/studio/src/kitchen-sink/pages-global.stories.tsx
+++ b/apps/studio/src/kitchen-sink/pages-global.stories.tsx
@@ -1,0 +1,53 @@
+import { FullScreenError } from "@director.run/design/components/pages/global/error.tsx";
+import { FullScreenLoader } from "@director.run/design/components/pages/global/loader.tsx";
+import type { Meta, StoryObj } from "@storybook/react";
+
+/**
+ * Global full-screen states used across the app for loading and hard errors.
+ * These have no stories in the app today.
+ */
+const meta = {
+  title: "kitchen-sink/pages/global-states",
+  component: FullScreenError,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof FullScreenError>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Loader: Story = {
+  render: () => <FullScreenLoader />,
+  parameters: { chromatic: { disableSnapshot: true } },
+};
+
+export const ErrorDeadSmiley: Story = {
+  args: {
+    icon: "dead-smiley",
+    fullScreen: true,
+    title: "Unexpected Error",
+    subtitle: "Something went wrong. Please try again.",
+  },
+};
+
+export const ErrorPlugs: Story = {
+  args: {
+    icon: "plugs",
+    fullScreen: true,
+    title: "Disconnected",
+    subtitle: "We lost connection to the gateway.",
+  },
+};
+
+export const ErrorWithData: Story = {
+  args: {
+    icon: "dead-smiley",
+    fullScreen: true,
+    title: "Request failed",
+    subtitle: "The gateway returned an error.",
+    data: {
+      code: "INTERNAL_SERVER_ERROR",
+      path: "store.get",
+      message: "Playbook not found",
+    },
+  },
+};

--- a/apps/studio/src/kitchen-sink/pages-library.stories.tsx
+++ b/apps/studio/src/kitchen-sink/pages-library.stories.tsx
@@ -1,0 +1,63 @@
+import { LayoutRoot } from "@director.run/design/components/layout/layout.tsx";
+import type { NavigationSection } from "@director.run/design/components/layout/navigation.tsx";
+import { MCPIcon } from "@director.run/design/components/ui/icons/mcp-icon.tsx";
+import type { Decorator, Meta, StoryObj } from "@storybook/react";
+import { kitchenSinkPlaybooks } from "./lib/fixtures";
+import { LibraryRoute } from "./lib/routes/library-route";
+
+const sections: NavigationSection[] = [
+  {
+    id: "registries",
+    label: "Registries",
+    items: [{ id: "mcp", label: "MCP", icon: <MCPIcon />, isActive: true }],
+  },
+  {
+    id: "playbooks",
+    label: "Playbooks",
+    items: kitchenSinkPlaybooks().map((playbook) => ({
+      id: playbook.id,
+      label: playbook.name,
+    })),
+  },
+];
+
+const withSidebar: Decorator = (Story) => (
+  <LayoutRoot sections={sections}>
+    <Story />
+  </LayoutRoot>
+);
+
+/**
+ * The registry library page in each of its states. The real app has only a
+ * loading-skeleton story today; these cover the populated, empty-search and
+ * error states too. Interactive version: `kitchen-sink/app`.
+ */
+const meta = {
+  title: "kitchen-sink/pages/library",
+  component: LibraryRoute,
+  parameters: { layout: "fullscreen" },
+  decorators: [withSidebar],
+  args: {
+    playbooks: kitchenSinkPlaybooks(),
+    navigate: () => {},
+    pageState: "default",
+  },
+} satisfies Meta<typeof LibraryRoute>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const EmptySearch: Story = {
+  args: { initialSearchQuery: "no-such-server-xyz" },
+};
+
+export const Loading: Story = {
+  args: { pageState: "loading" },
+  parameters: { chromatic: { disableSnapshot: true } },
+};
+
+export const Error: Story = {
+  args: { pageState: "error" },
+};


### PR DESCRIPTION
## Summary
Adds a comprehensive **kitchen-sink Storybook** to `apps/studio` for examining the whole design system in one place. Dev-tooling only — no product runtime code changes; the real app and `packages/design` are untouched.

- **Support code + preview config** (`8b8cc6b`): a mock app shell with an in-memory router, fixtures, seven route mocks, and four component galleries under `src/kitchen-sink/lib`; plus a working dark-mode toolbar decorator and viewport options in `.storybook/preview.tsx` (renamed from `.ts`).
- **Stories** (`09b284b`): the flagship `kitchen-sink/app` interactive mock (live sidebar nav, menus, sheets, dialogs, toasts; 10 variants incl. Mobile/Tablet/SidebarLoading/LoadingStates/EmptyStates/ErrorState/Onboarding/DarkMode), page-state sub-stories (`library`, `global-states`, OAuth `connect`), and galleries for every primitive/form/overlay/content component plus an `all-components` page.

## Test Coverage
`@director.run/studio` has no unit-test suite. Correctness was verified by `storybook build` (compiles every story) and live browser QA via Playwright: sidebar navigation, actions dropdown to settings sheet, mobile hamburger nav, and gallery rendering, with zero console errors beyond expected offline icon 404s.

## Pre-Landing Review
- Codex adversarial pass: **NO MATERIAL FINDINGS**.
- Claude review: 4 informational findings, no correctness bugs. 2 auto-fixed — added a Toaster to the forms gallery so submit feedback renders in its standalone story, and the onboarding install dialog now reflects the clicked registry entry instead of always GitHub. 2 skipped with reason: the object-cast-to-Error is intentional (the story export is named `Error`, which shadows the constructor — matches the repo's existing login stories), and the `mockTools()` cast is load-bearing (matches `playbook-detail.stories.tsx`).

## Design Review
Frontend diff, but it showcases the existing design system rather than introducing new UI. No new design patterns; components are used per their real APIs.

## Plan Completion
Complete. All planned milestones delivered: preview config, types + fixtures, app shell plus seven routes, ten app variants, three page-state story files, four galleries and an all-components page. lint, typecheck, and build all green.

## Notes
- `@director.run/studio` is in the changeset `ignore` list and is private, so no changeset or version bump applies.
- Follow-ups (out of scope): dark mode is wired but visually minimal until `.dark` design tokens are defined; three real pages nest `LayoutView` inside the root layout's (the mock reproduces this faithfully); `not-found-page.tsx` bypasses the design system.

## Test plan
- [x] `bun run lint` — clean (all packages)
- [x] `bun run typecheck` — clean (all packages)
- [x] `bun run build` (studio) — vite + storybook build succeed
- [x] Live Storybook QA via Playwright — navigation, menus, sheets, mobile nav, galleries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
