### PR TITLE
Make dark mode work in the kitchen-sink Storybook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ When building frontend components (Studio, design system):
 
 2. **Storybook Requirement**:
    - When creating a new dumb/presentational component, you MUST also create a Storybook story
-   - Stories go in `packages/design/src/components/` alongside the component
+   - Stories live in `apps/studio/src/` (Storybook runs from the studio app): design-system coverage in `src/kitchen-sink/`, app-specific stories alongside their components
    - Stories should demonstrate all component variants and states
    - Use the `*.stories.tsx` naming convention
 
@@ -114,7 +114,7 @@ When building frontend components (Studio, design system):
    - Style with the semantic tokens defined in `apps/studio/src/globals.css` (`bg`, `fg`, `fg-subtle`, `surface`, `accent`, `accent-subtle`, `success`, `success-fg`, `destructive`, `destructive-fg`, `overlay`)
    - The default Tailwind palette is disabled (`--color-*: initial`) — classes like `text-green-500` or `bg-red-50` silently produce no CSS
    - Use the semantic shadow utilities (`shadow-hairline`, `shadow-raised`, `shadow-panel`, `shadow-popover`) instead of hardcoded `shadow-[...]` values
-   - Components must render correctly in both light and dark mode (`.dark` class); add a `DarkMode` story variant (`globals: { darkMode: true }`) alongside new stories
+   - Components must render correctly in both light and dark mode (`.dark` class); add dark story variants (`globals: { darkMode: true }`) alongside new stories — named `DarkMode`, or state-specific like `ConsentDarkMode`
    - See `packages/design/README.md` for the full token reference
 
 ### Testing Requirements
@@ -161,8 +161,8 @@ When building frontend components (Studio, design system):
 
 ### Development Standards
 
-- **Package Manager**: Bun (version ~1.2.5)
-- **Node Version**: ~23.10.0
+- **Package Manager**: Bun (version 1.3.2)
+- **Node Version**: >=22.0.0
 - **Monorepo**: Turborepo with workspaces
 - **Linting**: Biome with strict rules (no default exports, no explicit any)
 - **Testing**: Vitest with file parallelism disabled

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,13 @@ When building frontend components (Studio, design system):
    - Reusable presentational components: `packages/design/src/components/`
    - App-specific containers/pages: `apps/studio/src/pages/` or `apps/studio/src/components/`
 
+4. **Theming and Dark Mode**:
+   - Style with the semantic tokens defined in `apps/studio/src/globals.css` (`bg`, `fg`, `fg-subtle`, `surface`, `accent`, `accent-subtle`, `success`, `success-fg`, `destructive`, `destructive-fg`, `overlay`)
+   - The default Tailwind palette is disabled (`--color-*: initial`) — classes like `text-green-500` or `bg-red-50` silently produce no CSS
+   - Use the semantic shadow utilities (`shadow-hairline`, `shadow-raised`, `shadow-panel`, `shadow-popover`) instead of hardcoded `shadow-[...]` values
+   - Components must render correctly in both light and dark mode (`.dark` class); add a `DarkMode` story variant (`globals: { darkMode: true }`) alongside new stories
+   - See `packages/design/README.md` for the full token reference
+
 ### Testing Requirements
 
 - Write tests for new functionality

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,67 @@
+# TODOS
+
+## Design System
+
+### Sanitize raw HTML in registry markdown rendering
+
+**What:** Filter or sanitize the raw HTML that `packages/design/src/components/ui/markdown.tsx` renders via `rehypeRaw` (e.g. rehype-sanitize, or an `allowElement` allowlist that drops `<style>`, `<script>`, `<iframe>` and inline `style` attributes).
+
+**Why:** Registry readmes and MCP tool descriptions are untrusted third-party content. With `rehypeRaw` unfiltered, a malicious readme can inject `<style>` blocks or inline styles and restyle the entire page — spoof UI, hide consent dialogs, or corrupt theming.
+
+**Context:** Flagged by adversarial review on PR #487 (dark mode). Pre-existing, not introduced by that PR — arbitrary CSS injection is possible regardless of token naming. `Markdown` is used for registry item readmes and tool descriptions. Start at `markdown.tsx` where `rehypeRaw` is registered; decide whether any raw HTML is actually needed (if not, dropping `rehypeRaw` entirely is the simplest fix).
+
+**Effort:** S
+**Priority:** P1
+**Depends on:** None
+
+### Remove ghost shadcn tokens from form components
+
+**What:** Replace non-resolving utility classes (`border-input`, `ring-ring`, `text-foreground`, `text-muted-foreground`, `shadow-xs`, `decoration-gray-10/12`) in `input.tsx`, `textarea.tsx`, `select-native.tsx`, `switch.tsx`, `typography.tsx`, and `playbook-manual-connection-dialog.tsx` with the semantic tokens from `apps/studio/src/globals.css`.
+
+**Why:** These classes reference shadcn theme variables that were never defined in this codebase, so they compile to nothing or fall back to `currentColor` — focus rings and borders render by accident, not by design. They also contradict the token rule now documented in CLAUDE.md and the design README.
+
+**Context:** Found during PR #487 review (dead-palette class sweep fixed the same bug class elsewhere: `text-green-500`, `border-red-200`, `text-accent-red`). These are the shadcn-derived leftovers. Verify each swap in the kitchen-sink forms stories in both light and dark mode.
+
+**Effort:** S
+**Priority:** P2
+**Depends on:** None
+
+### Deduplicate the mobile sidebar sheet
+
+**What:** Extract the duplicated mobile sidebar sheet markup (Radix Dialog + `shadow-panel` + close button) shared between `packages/design/src/components/layout/layout.tsx` and `packages/design/src/components/layout/navigation.tsx` into one component.
+
+**Why:** Two near-identical copies already drifted once (the PR #487 shadow swap had to patch both); the next styling change will need to remember both call sites or they diverge visibly.
+
+**Context:** Flagged by the maintainability specialist on PR #487. Compare `LayoutViewSidebar`'s sheet in `layout.tsx` with the sheet in `navigation.tsx`; the diff is small. A story that opens the hamburger nav would also close one of the Chromatic coverage gaps noted below.
+
+**Effort:** M
+**Priority:** P3
+**Depends on:** None
+
+### Theme the brand SVGs for dark mode
+
+**What:** Make the client/brand logos in `packages/design/src/components/connect/connection-brands.tsx` dark-mode aware (they hardcode `#FFF` / `#F3F3F3` fills and gradient stops).
+
+**Why:** Once the connect flows get dark treatment, near-white logo fills will glare on the dark `surface`; there is currently no DarkMode story covering them so the regression would land silently.
+
+**Context:** Flagged by adversarial review on PR #487 as future scope — the connect empty/update states (`connection-empty-state.tsx`, `connection-update-state.tsx`) render these SVGs. Options: `currentColor`, CSS-variable fills, or per-mode variants. Add a DarkMode story alongside.
+
+**Effort:** M
+**Priority:** P3
+**Depends on:** None
+
+## Storybook
+
+### Close interaction-gated Chromatic coverage gaps
+
+**What:** Add `play()` functions (or dedicated stories) for the three uncovered visual states from PR #487: the get-started install-server dialog open on mobile, the mobile hamburger sidebar sheet open, and the inactive-tab hover state.
+
+**Why:** These are the only `shadow-hairline`/`shadow-panel` call sites with no Chromatic snapshot in either theme — a dark-mode or elevation regression there ships unseen. Coverage is currently 11/14 paths (~79%).
+
+**Context:** Coverage audit in PR #487's Test Coverage section lists the exact gaps. `@storybook/test` is available for `play()` interactions; the sidebar-sheet story overlaps with the dedup item above.
+
+**Effort:** S
+**Priority:** P3
+**Depends on:** None
+
+## Completed

--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -28,19 +28,6 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
-    backgrounds: {
-      default: "light",
-      values: [
-        {
-          name: "light",
-          value: "#ffffff",
-        },
-        {
-          name: "dark",
-          value: "#1a1a1a",
-        },
-      ],
-    },
     viewport: {
       options: {
         ...MINIMAL_VIEWPORTS,

--- a/apps/studio/src/components/sheets/prompt-sheet.stories.tsx
+++ b/apps/studio/src/components/sheets/prompt-sheet.stories.tsx
@@ -39,3 +39,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const DarkMode: Story = {
+  globals: { darkMode: true },
+};

--- a/apps/studio/src/globals.css
+++ b/apps/studio/src/globals.css
@@ -6,32 +6,108 @@
 
 @plugin "tailwindcss-radix";
 
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:is(.dark, .dark *));
+
+:root {
+  color-scheme: light;
+
+  /* Background */
+  --bg: oklch(95.61% 0.003 67.78);
+
+  /* Foreground */
+  --fg: oklch(32.10% 0.010 61.13);
+  --fg-subtle: oklch(51.08% 0.007 84.58);
+
+  /* Surface */
+  --surface: oklch(99.45% 0.002 67.80);
+
+  /* Accent */
+  --accent: oklch(90.98% 0.007 53.44);
+  --accent-subtle: oklch(93.88% 0.004 56.37);
+
+  /* Success */
+  --success: oklch(92.85% 0.041 135.05);
+  --success-fg: oklch(48.75% 0.106 136.30);
+
+  /* Destructive */
+  --destructive: oklch(87.20% 0.053 22.57);
+  --destructive-fg: oklch(46.45% 0.178 29.65);
+
+  /* Overlay scrim */
+  --overlay: rgb(55 50 46 / 0.25);
+
+  /* Elevation — named --elevation-* (not --shadow-*) because a raw var
+     sharing a @theme key's name would self-reference under @theme inline.
+     Colors are baked in per mode, so shadow-color utilities don't compose
+     with these tokens */
+  --elevation-hairline: 0 0 0 0.5px rgb(55 50 46 / 0.15);
+  --elevation-raised:
+    0 3px 9px 0 rgb(55 50 46 / 0.07), 0 0 0 0.5px rgb(55 50 46 / 0.15);
+  --elevation-panel:
+    0 0 10px 3px rgb(55 50 46 / 0.13), 0 0 0 0.5px rgb(55 50 46 / 0.2);
+  --elevation-popover:
+    0 3px 9px 0 rgb(55 50 46 / 0.1), 0 0 20px 2px rgb(55 50 46 / 0.07),
+    0 0 0 0.5px rgb(55 50 46 / 0.1);
+}
+
+.dark {
+  color-scheme: dark;
+
+  /* Background */
+  --bg: oklch(21% 0.008 61);
+
+  /* Foreground */
+  --fg: oklch(92% 0.006 67);
+  --fg-subtle: oklch(69% 0.008 75);
+
+  /* Surface */
+  --surface: oklch(25% 0.009 61);
+
+  /* Accent */
+  --accent: oklch(33% 0.010 55);
+  --accent-subtle: oklch(29% 0.008 58);
+
+  /* Success */
+  --success: oklch(35% 0.055 136);
+  --success-fg: oklch(87% 0.10 135);
+
+  /* Destructive */
+  --destructive: oklch(33% 0.08 25);
+  --destructive-fg: oklch(83% 0.11 25);
+
+  /* Overlay scrim */
+  --overlay: rgb(0 0 0 / 0.5);
+
+  /* Elevation */
+  --elevation-hairline: 0 0 0 0.5px rgb(255 250 240 / 0.16);
+  --elevation-raised:
+    0 3px 9px 0 rgb(0 0 0 / 0.35), 0 0 0 0.5px rgb(255 250 240 / 0.16);
+  --elevation-panel:
+    0 0 10px 3px rgb(0 0 0 / 0.5), 0 0 0 0.5px rgb(255 250 240 / 0.18);
+  --elevation-popover:
+    0 3px 9px 0 rgb(0 0 0 / 0.4), 0 0 20px 2px rgb(0 0 0 / 0.3),
+    0 0 0 0.5px rgb(255 250 240 / 0.16);
+}
 
 @theme inline {
   --color-*: initial;
 
-  /* Background */
-  --color-bg: oklch(95.61% 0.003 67.78);
+  --color-bg: var(--bg);
+  --color-fg: var(--fg);
+  --color-fg-subtle: var(--fg-subtle);
+  --color-surface: var(--surface);
+  --color-accent: var(--accent);
+  --color-accent-subtle: var(--accent-subtle);
+  --color-success: var(--success);
+  --color-success-fg: var(--success-fg);
+  --color-destructive: var(--destructive);
+  --color-destructive-fg: var(--destructive-fg);
+  --color-overlay: var(--overlay);
 
-  /* Foreground */
-  --color-fg: oklch(32.10% 0.010 61.13);
-  --color-fg-subtle: oklch(51.08% 0.007 84.58);
-
-  /* Surface */
-  --color-surface: oklch(99.45% 0.002 67.80);
-
-  /* Accent */
-  --color-accent: oklch(90.98% 0.007 53.44);
-  --color-accent-subtle: oklch(93.88% 0.004 56.37);
-  
-  /* Success */
-  --color-success: oklch(92.85% 0.041 135.05);
-  --color-success-fg: oklch(48.75% 0.106 136.30);
-
-  /* Destructive */
-  --color-destructive: oklch(87.20% 0.053 22.57);
-  --color-destructive-fg: oklch(46.45% 0.178 29.65);
+  --shadow-hairline: var(--elevation-hairline);
+  --shadow-raised: var(--elevation-raised);
+  --shadow-panel: var(--elevation-panel);
+  --shadow-popover: var(--elevation-popover);
 
   --font-sans: var(--font-sans);
   --font-mono: var(--font-mono);
@@ -51,11 +127,11 @@
 @layer components {
   .popover {
     @apply z-50 bg-surface text-fg outline-none rounded-lg overflow-y-auto overflow-x-hidden;
-    @apply shadow-[0_3px_9px_0px_rgba(55,50,46,0.1),0_0_20px_2px_rgba(55,50,46,0.07),_0_0_0_0.5px_rgba(55,50,46,0.1)];
+    @apply shadow-popover;
   }
 
   .overlay {
-    @apply fixed inset-0 z-50 bg-fg/25 backdrop-blur-xs;
+    @apply fixed inset-0 z-50 bg-overlay backdrop-blur-xs;
     @apply radix-state-[closed]:fade-out-0 radix-state-[closed]:animate-out;
     @apply radix-state-[open]:fade-in-0 radix-state-[open]:animate-in;
   }

--- a/apps/studio/src/kitchen-sink/components-content.stories.tsx
+++ b/apps/studio/src/kitchen-sink/components-content.stories.tsx
@@ -15,3 +15,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const DarkMode: Story = {
+  globals: { darkMode: true },
+};

--- a/apps/studio/src/kitchen-sink/components-forms.stories.tsx
+++ b/apps/studio/src/kitchen-sink/components-forms.stories.tsx
@@ -15,3 +15,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const DarkMode: Story = {
+  globals: { darkMode: true },
+};

--- a/apps/studio/src/kitchen-sink/components-overlays.stories.tsx
+++ b/apps/studio/src/kitchen-sink/components-overlays.stories.tsx
@@ -15,3 +15,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const DarkMode: Story = {
+  globals: { darkMode: true },
+};

--- a/apps/studio/src/kitchen-sink/pages-connect.stories.tsx
+++ b/apps/studio/src/kitchen-sink/pages-connect.stories.tsx
@@ -49,3 +49,8 @@ export const Error: Story = {
     error: { message: "Authorization failed. Please try again." } as Error,
   },
 };
+
+export const ConsentDarkMode: Story = {
+  args: { isAuthenticated: true, scopes, redirectUri },
+  globals: { darkMode: true },
+};

--- a/packages/design/README.md
+++ b/packages/design/README.md
@@ -37,6 +37,11 @@ automatically:
 - `shadow-panel` — sheets and side panels
 - `shadow-popover` — popovers, dropdowns, dialogs
 
+The underlying `--elevation-*` custom properties in `globals.css` are
+implementation-private (they exist so the raw vars don't self-reference
+the `--shadow-*` theme keys under `@theme inline`) — use the `shadow-*`
+utilities, not the vars.
+
 ### Storybook
 
 Stories run from `apps/studio` (`bun run storybook` at the repo root). The

--- a/packages/design/README.md
+++ b/packages/design/README.md
@@ -1,3 +1,45 @@
 # Director Design Package
 
 Director design component library
+
+## Theming
+
+Components are styled with semantic design tokens defined in
+`apps/studio/src/globals.css` (the Tailwind v4 entry point). The default
+Tailwind palette is disabled (`--color-*: initial`), so default palette
+classes like `text-green-500` or `bg-red-50` produce no CSS — always use
+the semantic tokens below.
+
+Every token has a light and a dark value (a warm-charcoal OKLCH palette).
+Dark mode is activated by adding the `dark` class to an ancestor element;
+`color-scheme` is set per mode.
+
+### Color tokens
+
+| Token                            | Example utilities                       | Use for                      |
+| -------------------------------- | --------------------------------------- | ---------------------------- |
+| `bg`                             | `bg-bg`                                 | App background               |
+| `fg`, `fg-subtle`                | `text-fg`, `text-fg-subtle`             | Text and icons               |
+| `surface`                        | `bg-surface`                            | Cards, panels, popovers      |
+| `accent`, `accent-subtle`        | `bg-accent`, `bg-accent-subtle`         | Emphasized surfaces          |
+| `success`, `success-fg`          | `bg-success`, `text-success-fg`         | Positive states              |
+| `destructive`, `destructive-fg`  | `bg-destructive`, `text-destructive-fg` | Errors, destructive actions  |
+| `overlay`                        | `bg-overlay`                            | Modal and sheet scrims       |
+
+### Elevation
+
+Use the semantic shadow utilities instead of hardcoded `shadow-[...]`
+values. Shadow colors are baked in per mode, so they adapt to dark mode
+automatically:
+
+- `shadow-hairline` — 0.5px keyline around flat surfaces
+- `shadow-raised` — raised controls (e.g. active tabs)
+- `shadow-panel` — sheets and side panels
+- `shadow-popover` — popovers, dropdowns, dialogs
+
+### Storybook
+
+Stories run from `apps/studio` (`bun run storybook` at the repo root). The
+Storybook toolbar has a light/dark toggle, and a story can pin dark mode
+with `globals: { darkMode: true }` — see the `DarkMode` story variants in
+`apps/studio/src/kitchen-sink/`.

--- a/packages/design/cspell.json
+++ b/packages/design/cspell.json
@@ -10,5 +10,11 @@
     "tsconfig.tsbuildinfo",
     "src/test/fixtures/**"
   ],
-  "words": ["modelcontextprotocol", "invisibles", "streamable", "waitlist"]
+  "words": [
+    "modelcontextprotocol",
+    "invisibles",
+    "keyline",
+    "streamable",
+    "waitlist"
+  ]
 }

--- a/packages/design/src/components/forms/login-form.tsx
+++ b/packages/design/src/components/forms/login-form.tsx
@@ -31,7 +31,7 @@ export function LoginForm({
       defaultValues={
         defaultValues ? defaultValues : { email: "", password: "" }
       }
-      className="gap-y-0 overflow-hidden rounded-xl bg-accent-subtle shadow-[0_0_0_0.5px_rgba(55,50,46,0.15)]"
+      className="gap-y-0 overflow-hidden rounded-xl bg-accent-subtle shadow-hairline"
       onSubmit={(values) => {
         onSubmit({
           email: values.email,

--- a/packages/design/src/components/forms/signup-form.tsx
+++ b/packages/design/src/components/forms/signup-form.tsx
@@ -40,7 +40,7 @@ export function SignupForm({
           ? defaultValues
           : { email: "", password: "", confirmPassword: "" }
       }
-      className="gap-y-0 overflow-hidden rounded-xl bg-accent-subtle shadow-[0_0_0_0.5px_rgba(55,50,46,0.15)]"
+      className="gap-y-0 overflow-hidden rounded-xl bg-accent-subtle shadow-hairline"
       onSubmit={(values) => {
         onSubmit({
           email: values.email,

--- a/packages/design/src/components/get-started/get-started-connect.tsx
+++ b/packages/design/src/components/get-started/get-started-connect.tsx
@@ -119,7 +119,7 @@ export function GetStartedConnect({
             onClick={handleCopy}
             disabled={isLoading || !displayCommand}
           >
-            {copied ? <CheckIcon className="text-green-500" /> : <CopyIcon />}
+            {copied ? <CheckIcon className="text-success-fg" /> : <CopyIcon />}
           </Button>
         </div>
       </div>

--- a/packages/design/src/components/get-started/get-started-install-server-dialog.tsx
+++ b/packages/design/src/components/get-started/get-started-install-server-dialog.tsx
@@ -70,7 +70,7 @@ function GetStartedInstallServerDialogPresentation({
 
         {/* Mobile version */}
         <div className="-bottom-5 sticky inset-x-0 px-4 pt-4 md:hidden">
-          <div className="rounded-xl bg-accent-subtle p-4 shadow-[0_0_0_0.5px_rgba(55,50,46,0.2)]">
+          <div className="rounded-xl bg-accent-subtle p-4 shadow-hairline">
             {mcp && (
               <RegistryInstallForm
                 registryEntry={mcp}

--- a/packages/design/src/components/layout/layout.tsx
+++ b/packages/design/src/components/layout/layout.tsx
@@ -60,7 +60,7 @@ export function LayoutView({
     <div
       className={cn(
         "@container/page overflow-hidden text-fg",
-        "flex grow flex-col rounded-md bg-surface shadow-[0_0_0_0.5px_rgba(55,50,46,0.2)]",
+        "flex grow flex-col rounded-md bg-surface shadow-hairline",
         className,
       )}
       {...props}
@@ -98,7 +98,7 @@ export function LayoutViewHeader({
           <SheetPrimitive.Content
             className={cn(
               "fixed inset-y-0 left-0 z-50 h-full w-full max-w-[220px] bg-bg text-fg transition ease-in-out",
-              "shadow-[0_0_10px_3px_rgba(55,50,46,0.13),_0_0_0_0.5px_rgba(55,50,46,0.2)] outline-none",
+              "shadow-panel outline-none",
               "overflow-y-auto overflow-x-hidden",
               "radix-state-[closed]:slide-out-to-left radix-state-[closed]:animate-out radix-state-[closed]:duration-200",
               "radix-state-[open]:slide-in-from-left radix-state-[open]:animate-in radix-state-[open]:duration-300",

--- a/packages/design/src/components/layout/navigation.tsx
+++ b/packages/design/src/components/layout/navigation.tsx
@@ -81,7 +81,7 @@ function SidebarSheet({ children, sections, ...props }: SidebarSheetProps) {
         <SheetPrimitive.Content
           className={cn(
             "fixed inset-y-0 left-0 z-50 h-full w-full max-w-[220px] bg-bg text-fg transition ease-in-out",
-            "shadow-[0_0_10px_3px_rgba(55,50,46,0.13),_0_0_0_0.5px_rgba(55,50,46,0.2)] outline-none",
+            "shadow-panel outline-none",
             "overflow-y-auto overflow-x-hidden",
             "radix-state-[closed]:slide-out-to-left radix-state-[closed]:animate-out radix-state-[closed]:duration-200",
             "radix-state-[open]:slide-in-from-left radix-state-[open]:animate-in radix-state-[open]:duration-300",

--- a/packages/design/src/components/pages/auth/connect.tsx
+++ b/packages/design/src/components/pages/auth/connect.tsx
@@ -46,12 +46,12 @@ export function ConnectPage(props: Props) {
               </SectionHeader>
 
               {error && (
-                <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-600 text-sm">
+                <div className="rounded-lg bg-destructive p-4 text-destructive-fg text-sm">
                   {error.message}
                 </div>
               )}
 
-              <div className="rounded-xl bg-accent-subtle p-4 shadow-[0_0_0_0.5px_rgba(55,50,46,0.15)]">
+              <div className="rounded-xl bg-accent-subtle p-4 shadow-hairline">
                 <p className="mb-3 font-medium text-fg text-sm">
                   This will allow the application to:
                 </p>
@@ -119,7 +119,7 @@ export function ConnectPage(props: Props) {
               </SectionHeader>
 
               {error && (
-                <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-600 text-sm">
+                <div className="rounded-lg bg-destructive p-4 text-destructive-fg text-sm">
                   {error.message}
                 </div>
               )}

--- a/packages/design/src/components/playbooks-clients/playbook-section-clients.tsx
+++ b/packages/design/src/components/playbooks-clients/playbook-section-clients.tsx
@@ -46,7 +46,7 @@ export function PlaybookSectionClients({
           onCopy={handleCopy}
         ></PlaybookManualDialog>
       </SectionHeader>
-      <div className="overflow-hidden rounded-xl bg-accent-subtle p-4 shadow-[0_0_0_0.5px_rgba(55,50,46,0.15)]">
+      <div className="overflow-hidden rounded-xl bg-accent-subtle p-4 shadow-hairline">
         <LittleLabel>Connect Automatically</LittleLabel>
         {clients.map((client) => (
           <InstallerRow

--- a/packages/design/src/components/playbooks-clients/playbook-section-connect.tsx
+++ b/packages/design/src/components/playbooks-clients/playbook-section-connect.tsx
@@ -102,7 +102,7 @@ export function PlaybookSectionConnect({
         </SectionTitle>
       </SectionHeader>
 
-      <div className="flex w-full flex-col gap-y-0 overflow-hidden rounded-xl bg-accent-subtle shadow-[0_0_0_0.5px_rgba(55,50,46,0.15)]">
+      <div className="flex w-full flex-col gap-y-0 overflow-hidden rounded-xl bg-accent-subtle shadow-hairline">
         <div className="flex flex-col gap-y-4 p-4">
           <SelectNative
             className="w-full"
@@ -134,7 +134,7 @@ export function PlaybookSectionConnect({
                 disabled={isLoading || !displayCommand}
               >
                 {copied ? (
-                  <CheckIcon className="text-green-500" />
+                  <CheckIcon className="text-success-fg" />
                 ) : (
                   <CopyIcon />
                 )}

--- a/packages/design/src/components/registry/registry-install-form.tsx
+++ b/packages/design/src/components/registry/registry-install-form.tsx
@@ -92,7 +92,7 @@ export function RegistryInstallForm({
     <FormWithSchema
       schema={schema}
       defaultValues={defaultValues}
-      className="gap-y-0 overflow-hidden rounded-xl bg-accent-subtle shadow-[0_0_0_0.5px_rgba(55,50,46,0.15)]"
+      className="gap-y-0 overflow-hidden rounded-xl bg-accent-subtle shadow-hairline"
       onSubmit={(values) => {
         onSubmit({
           playbookId:

--- a/packages/design/src/components/settings/api-key-recycle-dialog.tsx
+++ b/packages/design/src/components/settings/api-key-recycle-dialog.tsx
@@ -92,7 +92,7 @@ export function ApiKeyRecycleDialog({
                 <div className="flex size-8 shrink-0 items-center justify-center rounded-r-md border-[0.5px] border-fg/20 bg-accent-subtle">
                   <Button size="icon" variant="ghost" onClick={handleCopy}>
                     {copied ? (
-                      <CheckIcon className="text-green-500" />
+                      <CheckIcon className="text-success-fg" />
                     ) : (
                       <CopyIcon />
                     )}

--- a/packages/design/src/components/ui/form.tsx
+++ b/packages/design/src/components/ui/form.tsx
@@ -149,7 +149,7 @@ function FormLabel(props: React.ComponentProps<typeof LabelPrimitive.Root>) {
 
   return (
     <Label
-      className={cn(error && "text-destructive", className)}
+      className={cn(error && "text-destructive-fg", className)}
       htmlFor={formItemId}
       {...rest}
     />
@@ -199,7 +199,7 @@ function FormMessage(props: React.ComponentProps<"p">) {
   return (
     <p
       id={formMessageId}
-      className={cn("text-accent-red text-sm", className)}
+      className={cn("text-destructive-fg text-sm", className)}
       {...rest}
     >
       {body}

--- a/packages/design/src/components/ui/input.tsx
+++ b/packages/design/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: ComponentProps<"input">) {
       className={cn(
         "flex h-8 w-full min-w-0 rounded-md border border-input bg-surface px-3 py-1 text-sm shadow-xs outline-none transition-[color,box-shadow] file:inline-flex file:h-7 file:border-0 file:bg-transparent file:font-medium file:text-foreground file:text-sm placeholder:text-muted-foreground/70 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
         "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
-        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive-fg dark:aria-invalid:ring-destructive-fg/40",
         type === "search" &&
           "[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none [&::-webkit-search-results-button]:appearance-none [&::-webkit-search-results-decoration]:appearance-none",
         type === "file" &&

--- a/packages/design/src/components/ui/json-schema.tsx
+++ b/packages/design/src/components/ui/json-schema.tsx
@@ -200,7 +200,7 @@ const UnionTypeRenderer: React.FC<UnionTypeRendererProps> = ({
     <div className="mt-4">
       <div className="mb-3 flex items-center gap-2">
         <Badge className="font-mono text-xs">{unionType}</Badge>
-        <span className="text-gray-600 text-sm">
+        <span className="text-fg-subtle text-sm">
           {getUnionDescription(unionType)}
         </span>
       </div>
@@ -345,7 +345,7 @@ function PropertyConstraints({ property }: { property: JsonSchemaProperty }) {
   }
 
   return (
-    <div className="mb-2 text-gray-500 text-sm">
+    <div className="mb-2 text-fg-subtle text-sm">
       {constraints.map(([key, value]) => (
         <div key={key}>
           <span className="font-medium">{key}:</span> {value}
@@ -361,7 +361,7 @@ function PropertyDefault({ property }: { property: JsonSchemaProperty }) {
   }
 
   return (
-    <div className="text-gray-600 text-sm">
+    <div className="text-fg-subtle text-sm">
       <span className="font-medium">Default:</span>{" "}
       {JSON.stringify(property.default)}
     </div>
@@ -374,7 +374,7 @@ function PropertyExample({ property }: { property: JsonSchemaProperty }) {
   }
 
   return (
-    <div className="text-gray-600 text-sm">
+    <div className="text-fg-subtle text-sm">
       <span className="font-medium">Example:</span>{" "}
       {JSON.stringify(property.example)}
     </div>

--- a/packages/design/src/components/ui/select-native.tsx
+++ b/packages/design/src/components/ui/select-native.tsx
@@ -15,7 +15,7 @@ const SelectNative = ({
       <select
         data-slot="select-native"
         className={cn(
-          "peer inline-flex cursor-pointer appearance-none items-center rounded-md border border-input bg-surface text-foreground text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 has-[option[disabled]:checked]:text-muted-foreground aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+          "peer inline-flex cursor-pointer appearance-none items-center rounded-md border border-input bg-surface text-foreground text-sm shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 has-[option[disabled]:checked]:text-muted-foreground aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive-fg dark:aria-invalid:ring-destructive-fg/40",
           props.multiple
             ? "py-1 *:px-3 *:py-1 [&_option:checked]:bg-accent"
             : "h-8 ps-3 pe-8",
@@ -26,7 +26,7 @@ const SelectNative = ({
         {children}
       </select>
       {!props.multiple && (
-        <span className="pointer-events-none absolute inset-y-0 end-2 flex h-full items-center justify-center text-muted-foreground/80 peer-disabled:opacity-50 peer-aria-invalid:text-destructive/80">
+        <span className="pointer-events-none absolute inset-y-0 end-2 flex h-full items-center justify-center text-muted-foreground/80 peer-disabled:opacity-50 peer-aria-invalid:text-destructive/80 dark:peer-aria-invalid:text-destructive-fg/80">
           <CaretUpDownIcon
             className="size-3"
             weight="bold"

--- a/packages/design/src/components/ui/sheet.tsx
+++ b/packages/design/src/components/ui/sheet.tsx
@@ -36,7 +36,7 @@ function SheetContent({
       <SheetPrimitive.Content
         className={cn(
           "popover fixed inset-y-1 right-1 z-50 flex w-[calc(100%-0.5rem)] flex-col overflow-hidden rounded-xl transition ease-in-out sm:max-w-xl",
-          "shadow-[0_0_10px_6px_rgba(55,50,46,0.13),_0_0_0_0.5px_rgba(55,50,46,0.25)]",
+          "shadow-panel",
           "radix-state-[open]:slide-in-from-right radix-state-[open]:animate-in radix-state-[open]:duration-300",
           "radix-state-[closed]:slide-out-to-right radix-state-[closed]:animate-out radix-state-[closed]:duration-200",
           className,

--- a/packages/design/src/components/ui/tabs.tsx
+++ b/packages/design/src/components/ui/tabs.tsx
@@ -49,8 +49,8 @@ function Tabs({ default: defaultValue, className, children }: TabsProps) {
             data-slot="tabs-trigger"
             className={cn(
               "inline-flex flex-1 cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap rounded-md px-3 py-1 font-[450] text-fg text-sm transition-[color,box-shadow]",
-              "radix-state-[active]:bg-surface radix-state-[active]:shadow-[0_3px_9px_0px_rgba(55,50,46,0.07),_0_0_0_0.5px_rgba(55,50,46,0.15)]",
-              "radix-state-[inactive]:hover:bg-surface/50 radix-state-[inactive]:hover:shadow-[0_0_0_0.5px_rgba(55,50,46,0.15)]",
+              "radix-state-[active]:bg-surface radix-state-[active]:shadow-raised",
+              "radix-state-[inactive]:hover:bg-surface/50 radix-state-[inactive]:hover:shadow-hairline",
               "disabled:pointer-events-none disabled:opacity-50 has-[svg:first-child]:pl-2.5",
               "[&_svg:not([class*='size-'])]:size-4.5 [&_svg]:pointer-events-none [&_svg]:shrink-0",
             )}

--- a/packages/design/src/components/ui/textarea.tsx
+++ b/packages/design/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "field-sizing-content flex min-h-19.5 w-full resize-none rounded-md border border-input bg-surface px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground/70 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        "field-sizing-content flex min-h-19.5 w-full resize-none rounded-md border border-input bg-surface px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground/70 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive-fg dark:aria-invalid:ring-destructive-fg/40",
         className,
       )}
       {...props}

--- a/packages/design/src/components/ui/typography.tsx
+++ b/packages/design/src/components/ui/typography.tsx
@@ -13,7 +13,7 @@ export const textVariants = cva("", {
     },
     invisibles: {
       false: "",
-      true: "[&:not(p)]:before:mr-2 [&:not(p)]:before:text-gray-8 [&:not(p)]:before:tracking-widest",
+      true: "[&:not(p)]:before:mr-2 [&:not(p)]:before:text-fg-subtle [&:not(p)]:before:tracking-widest",
     },
   },
   defaultVariants: {


### PR DESCRIPTION
## Summary

Dark mode in the kitchen-sink Storybook toggled the `.dark` class but nothing changed visually — every theme color was defined once, light-only. This PR makes dark mode actually work, with a warm-charcoal palette matching the light theme's warm-cream hue family.

**Theme tokens** (`805ee65`)
- `globals.css` restructured to the Tailwind v4 light/dark pattern: raw tokens in `:root`/`.dark` mapped through `@theme inline`, so utilities respond to the `.dark` class at runtime
- Dark palette in OKLCH: deep warm charcoal `bg` (21%), elevated `surface` (25%), warm off-white `fg` (92%), plus dark variants for accent/success/destructive — all pairs ≥ 6.4:1 contrast (WCAG AA)
- Semantic elevation tokens (`shadow-hairline`/`raised`/`panel`/`popover`): light mode keeps today's warm-gray shadows; dark mode flips hairline "borders" to translucent warm white and deepens blur layers
- Dedicated `bg-overlay` scrim token (the old `bg-fg/25` would have rendered a washed-out white scrim in dark mode)
- `color-scheme` set per mode so native controls and scrollbars follow the theme

**Shadow normalization** (`4282289`)
- 14 hardcoded `shadow-[…rgba(55,50,46,…)]` values across 11 design components collapse into the 4 semantic utilities
- Intentional light-mode deltas (hairline alphas 0.15/0.2/0.25 → one token; sheet's 6px-spread glow → shared panel tier): the sheet, LayoutView and get-started dialog read very slightly flatter — Chromatic will show these three for approval

**Dead-palette and error-state fixes** (`4958ce4`)
- `--color-*: initial` disables Tailwind's default palette, so `text-green-500`, `border-red-200 bg-red-50 text-red-600` and `text-accent-red` compiled to nothing (the connect-page error alert and form validation messages rendered unstyled). All swapped for semantic tokens
- `aria-invalid` borders/rings gained dark variants using `destructive-fg` — the fill-tier `destructive` token (33% lightness) was invisible as a border on dark surfaces. Verified visually in both themes

**Storybook** (`bfb4a49`)
- Removed the `backgrounds` addon parameter that painted `#ffffff` behind every story, fighting the theme
- Added `DarkMode` story variants: overlays/forms/content galleries, connect page, open prompt-sheet

**Docs** (`c8db805`, `3995433`)
- See Documentation section below

## Test Coverage

```
fix-storybook-darkmode — visual coverage (stories + Chromatic; unit tests N/A for pure CSS)

globals.css tokens
├─ .dark palette + dark elevation tokens ──── [★] kitchen-sink-app--dark-mode (Chromatic)
├─ :root light palette (unchanged-ness) ───── [★] all existing light stories (Chromatic baseline)
└─ backgrounds param removal (theme bg) ───── [★] every story canvas re-snapshot

className swaps (semantic shadow utilities)
├─ shadow-hairline: login/signup/connect/playbooks/registry ─ [★] existing page + gallery stories
├─ shadow-panel: ui/sheet (open) ──────────── [★] prompt-sheet stories incl. new DarkMode variant
├─ shadow-raised: tabs active state ───────── [★] content gallery incl. new DarkMode variant
├─ dark overlays/forms/tabs ───────────────── [★] new DarkMode gallery variants (this PR)
├─ shadow-hairline: get-started dialog ────── [GAP] dialog closed in stories (mobile-only div)
├─ shadow-panel: mobile sidebar sheet (x2) ── [GAP] no story opens the hamburger nav
└─ shadow-hairline: tabs inactive hover ───── [GAP] hover pseudo-state needs a play() fn

Dark-mode toggle flow (decorator — logic unchanged)
└─ globals.darkMode → .dark on <html> ─────── [★] DarkMode stories exercise the decorator
```

Coverage after adding the DarkMode variants: 11/14 paths (~79%, up from 71%). The 3 remaining gaps are interaction-gated states needing `play()` functions — noted as follow-ups. Manual verification: Playwright screenshots of app shell, primitives, forms (incl. invalid states), dialogs, sheets, menus in both themes.

## Pre-Landing Review

9 informational findings, 0 critical, from 4 specialists (testing, maintainability, performance, design) + checklist pass.
- Auto-fixed: dark-mode Chromatic gap (story variants), dead-palette classes, elevation-naming rationale comment
- Accepted as intentional (per approved plan): light-mode shadow normalization deltas; dark mode being Storybook-only for now
- Follow-ups (pre-existing, not this PR): sidebar sheet duplicated between `layout.tsx`/`navigation.tsx`; ghost shadcn tokens (`border-input`, `ring-ring`, `text-foreground`) that never resolve; brand SVGs hardcode near-white fills

## Adversarial Review

Claude adversarial + 2 Codex passes (design voice, adversarial challenge). Codex verified dark contrast ratios numerically (all ≥ 6.4:1) and compiled the CSS in-memory to confirm the `@theme inline` mappings resolve.

⚠️ **Pre-existing security flag worth a follow-up issue:** `packages/design/src/components/ui/markdown.tsx` renders registry/tool markdown with `rehypeRaw` and no element filtering — untrusted readmes can inject `<style>`/inline styles and restyle the page (predates this PR; arbitrary CSS injection is possible regardless of this PR's token names).

## Design Review

Design Review (lite): 4 findings — 3 fixed (dead palette classes, dark invalid-state visibility), 1 accepted (sheet shadow consolidation). AI Slop: clean. Codex design voice: NO FINDINGS.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN — intent was "make Storybook dark mode work"; the diff delivers exactly that plus same-class dead-token fixes found during review.

## Plan Completion

### Plan completion audit (3 plan items + 1 in-scope addition)
- [x] **globals.css light/dark token restructure** — DONE: `:root`/`.dark` blocks with `color-scheme`, all 10 dark OKLCH tokens, `@theme inline` var() mapping
- [x] **Semantic shadow tokens** — DONE: 4 tokens defined per-mode; all 14 hardcoded `rgba(55,50,46,…)` usages replaced (incl. 3 grep-caught files beyond the plan's list); zero literals remain
- [x] **preview.tsx backgrounds parameter removed** — DONE
- [~] **CHANGED (in-scope addition):** overlay scrim token — `bg-fg/25` would have rendered a light scrim in dark mode

## Verification Results

Plan verification: PASS — Storybook + Playwright visual checks in both themes (app shell, primitives, forms incl. validation states, dialogs, sheets, menus, scrim). Quality gates: lint 9/9, typecheck 9/9, build 5/5, tests 7/7 packages (registry excluded — pre-existing DB-dependent failures unrelated to this PR).

## Documentation

- `packages/design/README.md`: added a **Theming** reference — semantic color tokens (light/dark warm-charcoal OKLCH), elevation utilities (`shadow-hairline`/`raised`/`panel`/`popover`), the `bg-overlay` scrim token, dark-mode activation via the `.dark` class, and the `DarkMode` Storybook convention. Noted the `--elevation-*` CSS vars are implementation-private.
- `CLAUDE.md`: added a **Theming and Dark Mode** section (semantic tokens only; default Tailwind palette is disabled so classes like `text-green-500` silently produce no CSS; semantic shadow utilities; dark story variants required). Also fixed stale facts: Bun `~1.2.5` → `1.3.2`, Node `~23.10.0` → `>=22.0.0`, and the Storybook story location.

### Documentation Debt
- ⚠️ Legacy non-semantic utility classes remain in shipped components (`border-input`, `text-foreground`, `ring-ring`, `shadow-xs` in input/select-native/textarea/switch/typography) — code cleanup follow-up
- ⚠️ Theming has reference coverage only — no how-to walkthrough yet

## Test plan
- [x] Lint, typecheck, build all pass (9/9, 9/9, 5/5 turbo tasks)
- [x] Vitest passes for all packages except the pre-existing registry DB failures (7/7 with registry excluded)
- [x] Visual verification via Playwright in light and dark: app shell, galleries, forms + validation, overlays
- [ ] Review Chromatic diffs for the 3 intentional light-mode shadow normalizations (sheet, LayoutView, get-started dialog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
