### PR TITLE
fix(vscode): allow comments in settings.json by parsing it as JSONC

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -341,6 +341,7 @@
         "content-type": "^1.0.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "jsonc-parser": "^3.3.1",
         "lodash": "^4.17.21",
         "node-machine-id": "^1.1.12",
         "ora": "^8.2.0",
@@ -2151,7 +2152,7 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
-    "jsonc-parser": ["jsonc-parser@2.2.1", "", {}, "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="],
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
@@ -3256,6 +3257,8 @@
     "@segment/analytics-node/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
 
     "@stoplight/better-ajv-errors/leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
+
+    "@stoplight/json/jsonc-parser": ["jsonc-parser@2.2.1", "", {}, "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w=="],
 
     "@stoplight/json/safe-stable-stringify": ["safe-stable-stringify@1.1.1", "", {}, "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="],
 

--- a/packages/client-configurator/src/types.ts
+++ b/packages/client-configurator/src/types.ts
@@ -26,6 +26,10 @@ export abstract class AbstractClient<T> {
     this.logger = getLogger(`client-configurator/${this.name}`);
   }
 
+  protected getReadJSONFileOptions(): ReadJSONFileOptions | undefined {
+    return undefined;
+  }
+
   protected async initialize() {
     if (this.isInitialized && this.config) {
       return;
@@ -47,7 +51,7 @@ export abstract class AbstractClient<T> {
     }
 
     try {
-      this.config = await readJSONFile<T>(this.configPath);
+      this.config = await readJSONFile<T>(this.configPath, this.getReadJSONFileOptions());
       this.isInitialized = true;
     } catch (error) {
       // check if the error is a syntax error

--- a/packages/client-configurator/src/types.ts
+++ b/packages/client-configurator/src/types.ts
@@ -1,5 +1,5 @@
 import { AppError, ErrorCode } from "@director.run/utilities/error";
-import { readJSONFile } from "@director.run/utilities/json";
+import { readJSONFile, type ReadJSONFileOptions } from "@director.run/utilities/json";
 import { type Logger, getLogger } from "@director.run/utilities/logger";
 
 export type InstallerResult = {

--- a/packages/client-configurator/src/vscode.ts
+++ b/packages/client-configurator/src/vscode.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { isTest } from "@director.run/utilities/env";
 import { ErrorCode } from "@director.run/utilities/error";
 import { AppError } from "@director.run/utilities/error";
-import { writeJSONFile } from "@director.run/utilities/json";
+import { type ReadJSONFileOptions, writeJSONFile } from "@director.run/utilities/json";
 import { os, App } from "@director.run/utilities/os/index";
 import {
   AbstractClient,
@@ -12,6 +12,10 @@ import {
 } from "./types";
 
 export class VSCodeInstaller extends AbstractClient<VSCodeConfig> {
+  protected getReadJSONFileOptions(): ReadJSONFileOptions {
+    return { jsonc: true };
+  }
+
   public async isClientPresent() {
     return await os.isAppInstalled(App.VSCODE);
   }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -34,6 +34,7 @@
     "content-type": "^1.0.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "jsonc-parser": "^3.3.1",
     "lodash": "^4.17.21",
     "node-machine-id": "^1.1.12",
     "ora": "^8.2.0",

--- a/packages/utilities/src/json.ts
+++ b/packages/utilities/src/json.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { dirname } from "node:path";
 import { AppError, ErrorCode } from "./error";
 
-import { parse } from "jsonc-parser";
+import { parse, printParseErrorCode, type ParseError } from "jsonc-parser";
 
 export type ReadJSONFileOptions = {
   jsonc?: boolean;
@@ -21,10 +21,10 @@ export async function readJSONFile<T = unknown>(
   const data = new TextDecoder().decode(buffer);
   
   if (options?.jsonc) {
-    const errors: any[] = [];
+    const errors: ParseError[] = [];
     const parsed = parse(data, errors, { allowTrailingComma: true });
     if (errors.length > 0) {
-      throw new SyntaxError(`JSONC parse error: ${errors.map(e => e.error).join(', ')}`);
+      throw new SyntaxError(`JSONC parse error: ${errors.map(e => printParseErrorCode(e.error)).join(', ')}`);
     }
     return parsed as T;
   }

--- a/packages/utilities/src/json.ts
+++ b/packages/utilities/src/json.ts
@@ -3,15 +3,32 @@ import { existsSync } from "node:fs";
 import { dirname } from "node:path";
 import { AppError, ErrorCode } from "./error";
 
+import { parse } from "jsonc-parser";
+
+export type ReadJSONFileOptions = {
+  jsonc?: boolean;
+};
+
 export async function readJSONFile<T = unknown>(
   filePath: PathLike,
+  options?: ReadJSONFileOptions,
 ): Promise<T> {
   if (!existsSync(filePath)) {
     throw new AppError(ErrorCode.NOT_FOUND, `file not found at: ${filePath}`);
   }
 
   const buffer = await fs.promises.readFile(filePath);
-  let data = new TextDecoder().decode(buffer);
+  const data = new TextDecoder().decode(buffer);
+  
+  if (options?.jsonc) {
+    const errors: any[] = [];
+    const parsed = parse(data, errors, { allowTrailingComma: true });
+    if (errors.length > 0) {
+      throw new SyntaxError(`JSONC parse error: ${errors.map(e => e.error).join(', ')}`);
+    }
+    return parsed as T;
+  }
+  
   return JSON.parse(data) as T;
 }
 


### PR DESCRIPTION
Hey!

This PR fixes #458, where director fails to parse settings.json if it contains comments (which VSCode allows natively via JSONC).

I added jsonc-parser as a dependency and updated the eadJSONFile utility to accept a jsonc: true option. The VSCodeInstaller now overrides getReadJSONFileOptions to enable this, correctly parsing VSCode settings files even if they have comments. 

Let me know if there's anything else you'd like me to tweak!